### PR TITLE
MODDCB-27 Implement status transition from CHECKED OUT to CHECKED IN [Lending library]

### DIFF
--- a/src/main/java/org/folio/dcb/controller/TransactionApiController.java
+++ b/src/main/java/org/folio/dcb/controller/TransactionApiController.java
@@ -33,7 +33,7 @@ public class TransactionApiController implements TransactionsApi {
 
   @Override
   public ResponseEntity<TransactionStatusResponse> updateTransactionStatus(String dcbTransactionId, TransactionStatus transactionStatus) {
-    log.info("updateTransactionStatus:: updating dcbTransaction with id {} to status {} ", dcbTransactionId, transactionStatus);
+    log.info("updateTransactionStatus:: updating dcbTransaction with id {} to status {} ", dcbTransactionId, transactionStatus.getStatus());
     return ResponseEntity.status(HttpStatus.OK)
       .body(transactionsService.updateTransactionStatus(dcbTransactionId, transactionStatus));
   }

--- a/src/main/java/org/folio/dcb/listener/CirculationCheckInEventListener.java
+++ b/src/main/java/org/folio/dcb/listener/CirculationCheckInEventListener.java
@@ -30,7 +30,7 @@ public class CirculationCheckInEventListener {
     id = CHECK_IN_LISTENER_ID,
     topicPattern = "#{folioKafkaProperties.listener['check-in'].topicPattern}",
     concurrency = "#{folioKafkaProperties.listener['check-in'].concurrency}")
-  public void handleCheckingIn(String data, MessageHeaders messageHeaders) {
+  public void handleCheckInEvent(String data, MessageHeaders messageHeaders) {
     String tenantId = getHeaderValue(messageHeaders, XOkapiHeaders.TENANT, null).get(0);
     var checkInItemId = parseCheckInEvent(data);
     if (Objects.nonNull(checkInItemId)) {

--- a/src/main/java/org/folio/dcb/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/RequestServiceImpl.java
@@ -46,7 +46,7 @@ public class RequestServiceImpl implements RequestService {
       .requestType(CirculationRequest.RequestTypeEnum.PAGE)
       .requestLevel(CirculationRequest.RequestLevelEnum.ITEM)
       .fulfillmentPreference(CirculationRequest.FulfillmentPreferenceEnum.HOLD_SHELF)
-      .requester(Requester.builder().barcode(user.getBarcode()).build())
+      .requester(Requester.builder().barcode(user.getBarcode()).personal(user.getPersonal()).build())
       .item(Item.builder().barcode(item.getBarcode()).build())
       //As we don't know the servicePoint logic yet, proceeding with hardcoded value
       .pickupServicePointId("3a40852d-49fd-4df2-a1f9-6e2641a6e91f")

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -13,8 +13,6 @@ import org.folio.spring.exception.NotFoundException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
-
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -41,11 +39,9 @@ public class TransactionsServiceImpl implements TransactionsService {
           "Current transaction status equal to new transaction status: dcbTransactionId: %s, status: %s", dcbTransactionId, transactionStatus.getStatus()
         ));
       }
-
-      if (Objects.requireNonNull(dcbTransaction.getRole()) == DcbTransaction.RoleEnum.LENDER) {
-        lendingLibraryService.updateTransactionStatus(dcbTransaction, transactionStatus);
-      } else {
-        throw new IllegalArgumentException("Other roles are not implemented");
+      switch (dcbTransaction.getRole()) {
+        case LENDER -> lendingLibraryService.updateTransactionStatus(dcbTransaction, transactionStatus);
+        default -> throw new IllegalArgumentException("Other roles are not implemented");
       }
 
       return TransactionStatusResponse.builder()

--- a/src/main/java/org/folio/dcb/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.dcb.client.feign.UsersClient;
 import org.folio.dcb.domain.dto.DcbPatron;
+import org.folio.dcb.domain.dto.Personal;
 import org.folio.dcb.domain.dto.User;
 import org.folio.dcb.service.PatronGroupService;
 import org.folio.dcb.service.UserService;
@@ -18,8 +19,8 @@ public class UserServiceImpl implements UserService {
 
   private final PatronGroupService patronGroupService;
   private final UsersClient usersClient;
-
   private static final String DCB = "dcb";
+  private static final String LAST_NAME = "DcbSystem";
 
   public User fetchOrCreateUser(DcbPatron patronDetails) {
     log.debug("createOrFetchUser:: Trying to create or find user for userId {}, userBarcode {}",
@@ -27,7 +28,7 @@ public class UserServiceImpl implements UserService {
     var user = fetchUserByBarcodeAndId(patronDetails.getBarcode(), patronDetails.getId());
     if(Objects.isNull(user)) {
       log.info("fetchOrCreateUser:: Unable to find existing user with barcode {} and id {}. Hence, creating new user",
-        patronDetails.getId(), patronDetails.getBarcode());
+        patronDetails.getBarcode(), patronDetails.getId());
       user = createUser(patronDetails);
     }
     return user;
@@ -57,6 +58,7 @@ public class UserServiceImpl implements UserService {
       .patronGroup(groupId)
       .id(patron.getId())
       .type(DCB)
+      .personal(Personal.builder().lastName(LAST_NAME).build())
       .build();
   }
 }

--- a/src/main/resources/swagger.api/schemas/CirculationRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/CirculationRequest.yaml
@@ -80,3 +80,5 @@ requester:
     barcode:
       description: barcode of the item
       type: string
+    personal:
+      "$ref": "user.yaml#/Personal"

--- a/src/main/resources/swagger.api/schemas/CirculationRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/CirculationRequest.yaml
@@ -81,4 +81,4 @@ requester:
       description: barcode of the item
       type: string
     personal:
-      "$ref": "user.yaml#/Personal"
+      "$ref": "User.yaml#/Personal"

--- a/src/main/resources/swagger.api/schemas/User.yaml
+++ b/src/main/resources/swagger.api/schemas/User.yaml
@@ -21,7 +21,7 @@ User:
       description: A UUID corresponding to the group the user belongs to
       type: string
     personal:
-      "$ref": "user.yaml#/Personal"
+      "$ref": "User.yaml#/Personal"
 Personal:
   type: object
   properties:

--- a/src/main/resources/swagger.api/schemas/User.yaml
+++ b/src/main/resources/swagger.api/schemas/User.yaml
@@ -20,8 +20,8 @@ User:
     patronGroup:
       description: A UUID corresponding to the group the user belongs to
       type: string
-#    personal:
-#      "$ref": "user.yaml#/Personal"
+    personal:
+      "$ref": "user.yaml#/Personal"
 Personal:
   type: object
   properties:

--- a/src/main/resources/swagger.api/schemas/transactionStatus.yaml
+++ b/src/main/resources/swagger.api/schemas/transactionStatus.yaml
@@ -5,14 +5,10 @@ TransactionStatus:
       type: string
       enum:
         - CREATED #Created by DCB
-        - OPEN #Created in lending library, Item is available
-        - CANCELLED #Request canceled by lending library or patron
-        - IN_TRANSIT #checked in at another service point
-        - AWAITING_PICKUP #checked in at the same service point. Item status should change from "Checked out" to "Awaiting pickup"
-        - ITEM_CHECKED_OUT #Request is fulfilled and loan is created, Item checkout by patron
-        - ITEM_CHECKED_IN #Item returned to pickup location
-        - IN_TRANSIT_TO_LENDING #Item in transit from pickup location to owning library
+        - OPEN #Item checked in at lending library
+        - AWAITING_PICKUP #Item checked in at borrowing/Pickup library
+        - ITEM_CHECKED_OUT #Item checkout by patron. Request is fulfilled and loan is created
+        - ITEM_CHECKED_IN #Item returned to borrowing/Pickup library
         - CLOSED #Item returned to lending library
-        - ERROR #General error
     message:
       type: string

--- a/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
+++ b/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
@@ -119,6 +119,31 @@ class TransactionApiControllerTest extends BaseIT {
   }
 
   /**
+   * The test at the put endpoint invocation stage initiates stage verification from CHECKED_OUT to CHECKED_IN
+   * */
+  @Test
+  void transactionStatusUpdateFromCheckOutToCheckInTest() throws Exception {
+
+    var transactionID = UUID.randomUUID().toString();
+    var dcbTransaction = createTransactionEntity();
+    dcbTransaction.setStatus(TransactionStatus.StatusEnum.ITEM_CHECKED_OUT);
+    dcbTransaction.setRole(LENDER);
+    dcbTransaction.setId(transactionID);
+
+    systemUserScopedExecutionService.executeAsyncSystemUserScoped(TENANT, () -> transactionRepository.save(dcbTransaction));
+
+    this.mockMvc.perform(
+        put("/transactions/" + transactionID + "/status")
+          .content(asJsonString(createTransactionStatus(TransactionStatus.StatusEnum.ITEM_CHECKED_IN)))
+          .headers(defaultHeaders())
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.status").value("ITEM_CHECKED_IN"));
+  }
+
+
+  /**
    * The test at the post endpoint invocation stage initiates the data generation
    * then get stage verifies, the data exists.
    * */

--- a/src/test/java/org/folio/dcb/listener/CirculationCheckInEventListenerTest.java
+++ b/src/test/java/org/folio/dcb/listener/CirculationCheckInEventListenerTest.java
@@ -45,7 +45,7 @@ class CirculationCheckInEventListenerTest extends BaseIT {
     transactionEntity.setRole(LENDER);
     MessageHeaders messageHeaders = getMessageHeaders();
     when(transactionRepository.findTransactionByItemId(any())).thenReturn(Optional.of(transactionEntity));
-    eventListener.handleCheckingIn(CHECK_IN_EVENT_SAMPLE, messageHeaders);
+    eventListener.handleCheckInEvent(CHECK_IN_EVENT_SAMPLE, messageHeaders);
     Mockito.verify(libraryService, times(1)).updateStatusByTransactionEntity(any());
   }
 
@@ -54,7 +54,7 @@ class CirculationCheckInEventListenerTest extends BaseIT {
     var transactionEntity = createTransactionEntity();
     transactionEntity.setRole(LENDER);
     MessageHeaders messageHeaders = getMessageHeaders();
-    assertDoesNotThrow(() -> eventListener.handleCheckingIn(null, messageHeaders));
+    assertDoesNotThrow(() -> eventListener.handleCheckInEvent(null, messageHeaders));
   }
 
   private MessageHeaders getMessageHeaders() {

--- a/src/test/java/org/folio/dcb/service/CirculationServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/CirculationServiceTest.java
@@ -9,6 +9,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.folio.dcb.utils.EntityUtils.createTransactionEntity;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class CirculationServiceTest {
@@ -22,6 +24,7 @@ class CirculationServiceTest {
   @Test
   void checkInByBarcodeTest(){
     circulationService.checkInByBarcode(createTransactionEntity());
+    verify(circulationClient).checkInByBarcode(any());
   }
 
 }

--- a/src/test/java/org/folio/dcb/service/LendingLibraryServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/LendingLibraryServiceTest.java
@@ -112,7 +112,6 @@ class LendingLibraryServiceTest {
 
     lendingLibraryService.updateStatusByTransactionEntity(transactionEntity);
     Mockito.verify(transactionRepository, times(1)).save(transactionEntity);
-    Mockito.verify(circulationService, times(1)).checkInByBarcode(transactionEntity);
   }
 
   @Test
@@ -152,12 +151,21 @@ class LendingLibraryServiceTest {
   }
 
   @Test
+  void transactionStatusFromCheckoutToCheckInTest() {
+    TransactionEntity dcbTransaction = createTransactionEntity();
+    dcbTransaction.setStatus(TransactionStatus.StatusEnum.ITEM_CHECKED_OUT);
+    when(transactionRepository.save(dcbTransaction)).thenReturn(dcbTransaction);
+    lendingLibraryService.updateTransactionStatus(dcbTransaction, TransactionStatus.builder().status(TransactionStatus.StatusEnum.ITEM_CHECKED_IN).build());
+
+    verify(transactionRepository).save(dcbTransaction);
+
+    Assertions.assertEquals(TransactionStatus.StatusEnum.ITEM_CHECKED_IN, dcbTransaction.getStatus());
+  }
+
+  @Test
   void updateTransactionWithWrongStatusTest() {
     TransactionEntity transactionEntity = createTransactionEntity();
     TransactionStatus transactionStatus = createTransactionStatus(TransactionStatus.StatusEnum.AWAITING_PICKUP);
-    assertThrows(IllegalArgumentException.class, () -> {
-      TransactionEntity dcbTransaction = transactionEntity;
-      lendingLibraryService.updateTransactionStatus(dcbTransaction, transactionStatus);
-    });
+    assertThrows(IllegalArgumentException.class, () -> lendingLibraryService.updateTransactionStatus(transactionEntity, transactionStatus));
   }
 }


### PR DESCRIPTION
## Purpose
MODDCB-27 - https://issues.folio.org/browse/MODDCB-27 
Implement status transition from CHECKED OUT to CHECKED IN [Lending library] and added added personal object while creating user in order to avoid Null Pointer Exception while creating request in mod-circ.

## Approach
When we are receiving a PUT request with status CHECKED_IN , we update the status of the transaction from CHECKED_OUT to CHECKED_IN. In order to avoid NPE from mod-circ while creating request, we are creating a user with hard coded lastName as DcbSystem in personal object and used the personal object while creating user.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
