### PR TITLE
MODDCB-37: Secure setup of system users by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+ENV SYSTEM_USER_PASSWORD dcb-system-user
 # Copy your fat jar to the container
 ENV APP_FILE mod-dcb.jar
 # - should be a single jar file

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ requires and provides, the permissions, and the additional module metadata.
 | SYSTEM\_USER\_PASSWORD |        -        | Password of the system user                                                                                                                                         |
 ## Additional information
 
+### System user configuration
+The module uses system user to communicate with other modules.
+For production deployments you MUST specify the password for this system user via env variable:
+`SYSTEM_USER_PASSWORD=<password>`.
+
 ### Issue tracker
 
 See project [MODDCB](https://issues.folio.org/projects/MODDCB)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ For production deployments you MUST specify the password for this system user vi
 See project [MODDCB](https://issues.folio.org/projects/MODDCB)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
+### ModuleDescriptor
+
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+
 ### API documentation
 
 This module's [API documentation](https://dev.folio.org/reference/api/#mod-dcb).

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -123,7 +123,8 @@
       { "name": "DB_DATABASE", "value": "okapi_modules" },
       { "name": "DB_QUERYTIMEOUT", "value": "60000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
-      { "name": "DB_MAXPOOLSIZE", "value": "5" }
+      { "name": "DB_MAXPOOLSIZE", "value": "5" },
+      { "name": "SYSTEM_USER_PASSWORD", "value": "dcb-system-user" }
     ]
   }
 }

--- a/src/main/java/org/folio/dcb/DcbApplication.java
+++ b/src/main/java/org/folio/dcb/DcbApplication.java
@@ -11,14 +11,9 @@ public class DcbApplication {
   public static final String SYSTEM_USER_PASSWORD = "SYSTEM_USER_PASSWORD";
 
   public static void main(String[] args) {
-    checkIfSystemUserPasswordProvided();
-    SpringApplication.run(DcbApplication.class, args);
-  }
-
-  private static void checkIfSystemUserPasswordProvided() {
     if (StringUtils.isEmpty(System.getenv(SYSTEM_USER_PASSWORD))) {
       throw new IllegalArgumentException("Required environment variable is missing: " + SYSTEM_USER_PASSWORD);
     }
+    SpringApplication.run(DcbApplication.class, args);
   }
-
 }

--- a/src/main/java/org/folio/dcb/DcbApplication.java
+++ b/src/main/java/org/folio/dcb/DcbApplication.java
@@ -1,5 +1,6 @@
 package org.folio.dcb;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -7,9 +8,17 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SpringBootApplication
 @EnableFeignClients
 public class DcbApplication {
+  public static final String SYSTEM_USER_PASSWORD = "SYSTEM_USER_PASSWORD";
 
   public static void main(String[] args) {
+    checkIfSystemUserPasswordProvided();
     SpringApplication.run(DcbApplication.class, args);
+  }
+
+  private static void checkIfSystemUserPasswordProvided() {
+    if (StringUtils.isEmpty(System.getenv(SYSTEM_USER_PASSWORD))) {
+      throw new IllegalArgumentException("Required environment variable is missing: " + SYSTEM_USER_PASSWORD);
+    }
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,8 +49,8 @@ folio:
         topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${folio.environment}\.)[a-zA-z0-9-]+\.\w+\.check-in}
         group-id: ${folio.environment}-mod-dcb-group
   system-user:
-    username: dcb-system-user
-    password: ${SYSTEM_USER_PASSWORD:dcb-system-user}
+    username: ${SYSTEM_USER_NAME:dcb-system-user}
+    password: ${SYSTEM_USER_PASSWORD}
     lastname: System
     permissionsFilePath: permissions/mod-dcb.csv
   environment: ${ENV:folio}

--- a/src/test/java/org/folio/dcb/FolioDcbApplicationTest.java
+++ b/src/test/java/org/folio/dcb/FolioDcbApplicationTest.java
@@ -16,6 +16,10 @@ import org.folio.spring.liquibase.FolioLiquibaseConfiguration;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.folio.tenant.rest.resource.TenantApi;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class FolioDcbApplicationTest {
 
@@ -41,4 +45,9 @@ class FolioDcbApplicationTest {
     assertTrue(true);
   }
 
+  @Test
+  void exceptionOnMissingSystemUserPassword() {
+    var e = assertThrows(IllegalArgumentException.class, () -> DcbApplication.main(null));
+    assertThat(e.getMessage(), containsString(DcbApplication.SYSTEM_USER_PASSWORD));
+  }
 }

--- a/src/test/java/org/folio/dcb/controller/BaseIT.java
+++ b/src/test/java/org/folio/dcb/controller/BaseIT.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.support.TestPropertySourceUtils;
 import org.springframework.test.util.TestSocketUtils;
@@ -36,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(initializers = BaseIT.DockerPostgresDataSourceInitializer.class)
 @AutoConfigureMockMvc
 @Testcontainers
+@ActiveProfiles("test")
 public class BaseIT {
   @Autowired
   protected MockMvc mockMvc;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,25 +4,73 @@ spring:
   application:
     name: mod-dcb
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_DATABASE:db}
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}
+  sql:
+    init:
+      # to boot up application despite of any DB connection issues
+      continue-on-error: true
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    show-sql: false
   liquibase:
     enabled: true
-  jpa:
-    show-sql: true
+    change-log: classpath:db/changelog/changelog-master.xml
+  jackson:
+    default-property-inclusion: non_empty
+    deserialization:
+      fail-on-unknown-properties: false
+      accept-single-value-as-array: true
+  mustache:
+    check-template-location: false
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
 folio:
   tenant:
     validation:
-      enabled: false
+      enabled: true
+  kafka:
+    numberOfPartitions: ${NUMBER_OF_PARTITIONS:1}
+    replicationFactor: ${REPLICATION_FACTOR:1}
+    listener:
+      check-in:
+        concurrency: ${KAFKA_EVENTS_CONCURRENCY:5}
+        topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${folio.environment}\.)[a-zA-z0-9-]+\.\w+\.check-in}
+        group-id: ${folio.environment}-mod-dcb-group
   system-user:
     username: dcb-system-user
     password: dcb-system-user
     lastname: System
     permissionsFilePath: permissions/mod-dcb.csv
+  environment: ${ENV:folio}
+  okapi-url: ${OKAPI_URL:http://okapi:9130}
 management:
   endpoints:
-    enabled-by-default: false
-logging:
-  level:
-    org.springframework.web: debug
+    web:
+      exposure:
+        include: info,health,env,httptrace
+      base-path: /admin
+  #  endpoint:
+  #    health:
+  #      show-details: always
+  #      show-components: always
+  ###################################################
+  # Disable all checks except for readiness
+  ###################################################
+  health:
+    defaults:
+      enabled: false
+    readinessstate:
+      enabled: true
+debug: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,11 @@ folio:
   tenant:
     validation:
       enabled: false
+system-user:
+  username: dcb-system-user
+  password: dcb-system-user
+  lastname: System
+  permissionsFilePath: permissions/mod-dcb.csv
 management:
   endpoints:
     enabled-by-default: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,11 +15,11 @@ folio:
   tenant:
     validation:
       enabled: false
-system-user:
-  username: dcb-system-user
-  password: dcb-system-user
-  lastname: System
-  permissionsFilePath: permissions/mod-dcb.csv
+  system-user:
+    username: dcb-system-user
+    password: dcb-system-user
+    lastname: System
+    permissionsFilePath: permissions/mod-dcb.csv
 management:
   endpoints:
     enabled-by-default: false


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODDCB-37
To prevent unintended security holes by not setting username or password for created system users while deploying a module should fail at startup when username or password configuration is missing. For GDPR security by default is required. 

So every module should set up: 
system user name on a configuration variable. A default fallback value might be set.
system user password on a configuration variable. NO default fallback value should be set.

## Approach
system-user:
    username: ${SYSTEM_USER_NAME:some-system-user-name}
    password: ${SYSTEM_USER_PASSWORD}

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
