### PR TITLE
MODDCB-57: "apk upgrade" and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Only the fat jar file is needed for the Docker container
+*
+!target/*.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 ENV SYSTEM_USER_PASSWORD dcb-system-user
 # Copy your fat jar to the container
 ENV APP_FILE mod-dcb.jar


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODDCB-57
"apk upgrade" is missing in the Dockerfile. This puts mod-dcb at risk because the base Docker image does NOT get the fixed package when a security vulnerability is fixed.

In addition speed up the Docker build process by using a .dockerignore file.

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
