### PR TITLE
MODDCB-64: kafka-clients --> 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <folio-spring-system-user.version>7.2.0</folio-spring-system-user.version>
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
-    <kafkaclients.version>3.4.0</kafkaclients.version>
+    <kafkaclients.version>3.6.0</kafkaclients.version>
 
     <!-- test dependencies -->
     <wiremock.version>3.2.0</wiremock.version>


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODDCB-64
fix vulnerabilities:
https://security.snyk.io/package/maven/org.xerial.snappy:snappy-java

## Approach
consider upgrading kafka-clients from 3.4.0 to 3.6.0.

This will indirectly upgrade snappy-java from 1.1.8.4 to 1.1.10.4 fixing vulnerabilities:
https://security.snyk.io/package/maven/org.xerial.snappy:snappy-java

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
