### PR TITLE
MODDCB-67: ITEM_CHECKED_IN->CLOSED: Implement DCB transaction status …

### DIFF
--- a/src/main/java/org/folio/dcb/service/impl/BorrowingLibraryServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/BorrowingLibraryServiceImpl.java
@@ -11,8 +11,8 @@ import org.folio.dcb.service.CirculationService;
 import org.folio.dcb.service.LibraryService;
 import org.springframework.stereotype.Service;
 
-import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.AWAITING_PICKUP;
-import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.OPEN;
+import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.*;
+import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CLOSED;
 
 @Log4j2
 @Service("borrowingLibraryService")
@@ -40,6 +40,10 @@ public class BorrowingLibraryServiceImpl implements LibraryService {
     var requestedStatus = transactionStatus.getStatus();
     if(OPEN == currentStatus && AWAITING_PICKUP == requestedStatus) {
       circulationService.checkInByBarcode(dcbTransaction);
+      updateTransactionEntity(dcbTransaction, requestedStatus);
+    }else if (ITEM_CHECKED_IN == currentStatus && CLOSED == requestedStatus) {
+      log.info("updateTransactionStatus:: transaction status transition from {} to {} for the item with barcode {} ",
+        ITEM_CHECKED_IN.getValue(), CLOSED.getValue(), dcbTransaction.getItemBarcode());
       updateTransactionEntity(dcbTransaction, requestedStatus);
     } else {
       String error = String.format("updateTransactionStatus:: status update from %s to %s is not implemented", currentStatus, requestedStatus);

--- a/src/test/java/org/folio/dcb/service/BorrowingLibraryServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/BorrowingLibraryServiceTest.java
@@ -12,9 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.folio.dcb.domain.dto.DcbTransaction.RoleEnum.BORROWER;
-import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.AWAITING_PICKUP;
-import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CREATED;
-import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.OPEN;
+import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.*;
 import static org.folio.dcb.utils.EntityUtils.DCB_TRANSACTION_ID;
 import static org.folio.dcb.utils.EntityUtils.PICKUP_SERVICE_POINT_ID;
 import static org.folio.dcb.utils.EntityUtils.createDcbTransactionByRole;
@@ -61,6 +59,16 @@ class BorrowingLibraryServiceTest {
     borrowingLibraryService.createCirculation(DCB_TRANSACTION_ID, createDcbTransactionByRole(BORROWER), PICKUP_SERVICE_POINT_ID);
 
     verify(baseLibraryService).createBorrowingLibraryTransaction(DCB_TRANSACTION_ID, createDcbTransactionByRole(BORROWER), PICKUP_SERVICE_POINT_ID);
+  }
+
+  @Test
+  void testTransactionStatusUpdateFromItemCheckedInToClosed() {
+    var transactionEntity = createTransactionEntity();
+    transactionEntity.setStatus(ITEM_CHECKED_IN);
+    TransactionStatus transactionStatus = TransactionStatus.builder().status(CLOSED).build();
+    borrowingLibraryService.updateTransactionStatus(transactionEntity, transactionStatus);
+
+    Assertions.assertEquals(CLOSED, transactionEntity.getStatus());
   }
 
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODDCB-67
ITEM_CHECKED_IN->CLOSED: Implement DCB transaction status transition (Borrowing library)

## Approach

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
