### PR TITLE
MODDCB-59 DCB item effective location in Staff Slips

### DIFF
--- a/src/main/java/org/folio/dcb/domain/entity/TransactionEntity.java
+++ b/src/main/java/org/folio/dcb/domain/entity/TransactionEntity.java
@@ -49,6 +49,7 @@ public class TransactionEntity extends AuditableEntity {
   private String patronBarcode;
   private String borrowingLibraryCode;
   private UUID requestId;
+  private String agencyCode;
   @Enumerated(EnumType.STRING)
   private StatusEnum status;
   @Enumerated(EnumType.STRING)

--- a/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
+++ b/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
@@ -31,6 +31,7 @@ public class TransactionMapper {
       .patronId(patron.getId())
       .patronGroup(patron.getGroup())
       .borrowingLibraryCode(patron.getBorrowingLibraryCode())
+      .agencyCode(item.getAgencyCode())
 
       .role(dcbTransaction.getRole())
       .build();

--- a/src/main/java/org/folio/dcb/service/impl/CirculationItemServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/CirculationItemServiceImpl.java
@@ -63,6 +63,7 @@ public class CirculationItemServiceImpl implements CirculationItemService {
         .materialTypeId(materialTypeId)
         .permanentLoanTypeId(LOAN_TYPE_ID)
         .pickupLocation(pickupServicePointId)
+        .agencyCode(item.getAgencyCode())
         .build();
 
     circulationItemClient.createCirculationItem(item.getId(), circulationItemRequest);

--- a/src/main/resources/db/changelog/changes/add-agency-code.xml
+++ b/src/main/resources/db/changelog/changes/add-agency-code.xml
@@ -4,8 +4,13 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
-  <include file="changes/create-transaction-table.xml" relativeToChangelogFile="true"/>
-  <include file="changes/create-audit-table.xml" relativeToChangelogFile="true"/>
-  <include file="changes/add-request-to-transaction.xml" relativeToChangelogFile="true"/>
-  <include file="changes/add-agency-code.xml" relativeToChangelogFile="true"/>
+  <!-- Add agencyCode column -->
+  <changeSet id="addAgencyCodeColumn" author="magzhanArtykov">
+    <addColumn tableName="transactions">
+      <column name="agency_code" type="text">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/swagger.api/schemas/CirculationItemRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/CirculationItemRequest.yaml
@@ -20,4 +20,6 @@ CirculationItemRequest:
       type: string
     pickupLocation:
       type: string
+    agencyCode:
+      type: string
   additionalProperties: false

--- a/src/main/resources/swagger.api/schemas/dcbItem.yaml
+++ b/src/main/resources/swagger.api/schemas/dcbItem.yaml
@@ -17,3 +17,6 @@ DcbItem:
     lendingLibraryCode:
       description: The code which identifies the lending library
       type: string
+    agencyCode:
+      description: Effective 5 character agency code
+      type: string

--- a/src/test/java/org/folio/dcb/utils/EntityUtils.java
+++ b/src/test/java/org/folio/dcb/utils/EntityUtils.java
@@ -89,6 +89,7 @@ public class EntityUtils {
       .title("ITEM")
       .lendingLibraryCode("KU")
       .materialType("book")
+      .agencyCode("11191")
       .build();
   }
 
@@ -158,6 +159,7 @@ public class EntityUtils {
       .materialType("book")
       .lendingLibraryCode("LEN")
       .borrowingLibraryCode("BOR")
+      .agencyCode("11191")
       .requestId(UUID.fromString(CIRCULATION_REQUEST_ID))
       .build();
   }


### PR DESCRIPTION
Covers: [MODDCB-59](https://issues.folio.org/browse/MODDCB-59)

## Purpose
The purpose of the PR is to implement population of DCB item's effective location in print slips (Hold, Pick slip, Transit) and investigate which existing effective location tokens can be covered.

## Approach
Add agencyCode field to the DCB Transaction payload and persist. 
