### PR TITLE
MODDCB-98 Implement GET API for transaction updates with pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ dcb API provides the following URLs:
 | GET    | /transactions/{dcbTransactionId}/status                      | dcb.transactions.get      | Gets status of transaction based on transactionId                                   |
 | POST   | /transactions/{dcbTransactionId}                                             | dcb.transactions.post        | create new transaction                                                              |
 | PUT    | /transactions/{dcbTransactionId}/status                            | dcb.transactions.put         | Update the status of the transaction and it will trigger automatic action if needed |
+| GET    | /transactions/{dcbTransactionId}/status                            | dcb.transactions.collection.get         | get list of transaction updated between a given query range |
 
 ## Installing and deployment
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -212,8 +212,8 @@
     },
     {
       "permissionName": "dcb.transactions.collection.get",
-      "displayName": "get transaction detail list",
-      "description": "get list of transaction details"
+      "displayName": "get updated transaction detail list",
+      "description": "get list of transaction updated between a given query range"
     }
   ],
   "launchDescriptor": {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -122,6 +122,16 @@
             "circulation.check-out-by-barcode.post",
             "circulation.check-in-by-barcode.post"
           ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/transactions/status",
+          "permissionsRequired": [
+            "dcb.transactions.collection.get"
+          ],
+          "modulePermissions": []
         }
       ]
     },
@@ -181,7 +191,8 @@
       "subPermissions": [
         "dcb.transactions.post",
         "dcb.transactions.put",
-        "dcb.transactions.get"
+        "dcb.transactions.get",
+        "dcb.transactions.collection.get"
       ]
     },
     {
@@ -198,6 +209,11 @@
       "permissionName": "dcb.transactions.put",
       "displayName": "update transaction details",
       "description": "update transaction details"
+    },
+    {
+      "permissionName": "dcb.transactions.collection.get",
+      "displayName": "get transaction detail list",
+      "description": "get list of transaction details"
     }
   ],
   "launchDescriptor": {

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
                     <generateModelDocumentation>true</generateModelDocumentation>
                     <configOptions>
                       <generatedConstructorWithRequiredArgs>false</generatedConstructorWithRequiredArgs>
-                      <dateLibrary>java</dateLibrary>
+                      <dateLibrary>java8</dateLibrary>
                       <interfaceOnly>true</interfaceOnly>
                       <useSpringBoot3>true</useSpringBoot3>
                       <additionalModelTypeAnnotations>@lombok.Builder @lombok.NoArgsConstructor @lombok.AllArgsConstructor</additionalModelTypeAnnotations>

--- a/src/main/java/org/folio/dcb/config/JpaAuditingConfig.java
+++ b/src/main/java/org/folio/dcb/config/JpaAuditingConfig.java
@@ -2,15 +2,18 @@ package org.folio.dcb.config;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.spring.FolioExecutionContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
 @Configuration
-@EnableJpaAuditing(modifyOnCreate = false)
+@EnableJpaAuditing(dateTimeProviderRef = "dateTimeProvider", modifyOnCreate = false)
 @RequiredArgsConstructor
 public class JpaAuditingConfig implements AuditorAware<UUID>{
 
@@ -19,6 +22,11 @@ public class JpaAuditingConfig implements AuditorAware<UUID>{
   @Override
   public Optional<UUID> getCurrentAuditor() {
     return Optional.ofNullable(folioExecutionContext.getUserId());
+  }
+
+  @Bean
+  public DateTimeProvider dateTimeProvider() {
+    return () -> Optional.of(OffsetDateTime.now());
   }
 
 }

--- a/src/main/java/org/folio/dcb/controller/TransactionApiController.java
+++ b/src/main/java/org/folio/dcb/controller/TransactionApiController.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.dcb.domain.dto.DcbTransaction;
 import org.folio.dcb.domain.dto.TransactionStatus;
+import org.folio.dcb.domain.dto.TransactionStatusResponseCollection;
 import org.folio.dcb.rest.resource.TransactionsApi;
 import org.folio.dcb.domain.dto.TransactionStatusResponse;
 import org.folio.dcb.service.TransactionAuditService;
@@ -11,6 +12,7 @@ import org.folio.dcb.service.TransactionsService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import java.time.OffsetDateTime;
 
 @RestController
 @Log4j2
@@ -63,4 +65,13 @@ public class TransactionApiController implements TransactionsApi {
     return ResponseEntity.status(HttpStatus.OK)
       .body(transactionStatusResponse);
   }
+
+  @Override
+  public ResponseEntity<TransactionStatusResponseCollection> getTransactionStatusList(OffsetDateTime fromDate, OffsetDateTime toDate, Integer pageNumber, Integer pageSize) {
+    log.info("getTransactionStatusList:: fetching transaction lists with fromDate {}, toDate {}, pageNumber {}, pageSize {}",
+      fromDate, toDate, pageNumber, pageSize);
+    return ResponseEntity.status(HttpStatus.OK)
+      .body(transactionsService.getTransactionStatusList(fromDate, toDate, pageNumber, pageSize));
+  }
+
 }

--- a/src/main/java/org/folio/dcb/domain/entity/base/AuditableEntity.java
+++ b/src/main/java/org/folio/dcb/domain/entity/base/AuditableEntity.java
@@ -13,7 +13,7 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Getter
@@ -26,7 +26,7 @@ public abstract class AuditableEntity {
   @JsonIgnore
   @CreatedDate
   @Column(name = "created_date", nullable = false, updatable = false)
-  private LocalDateTime createdDate;
+  private OffsetDateTime createdDate;
 
   @JsonIgnore
   @CreatedBy
@@ -36,7 +36,7 @@ public abstract class AuditableEntity {
   @JsonIgnore
   @LastModifiedDate
   @Column(name = "updated_date")
-  private LocalDateTime updatedDate;
+  private OffsetDateTime updatedDate;
 
   @JsonIgnore
   @LastModifiedBy

--- a/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
+++ b/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
@@ -1,8 +1,14 @@
 package org.folio.dcb.domain.mapper;
 
+import org.folio.dcb.domain.dto.DcbItem;
+import org.folio.dcb.domain.dto.DcbPatron;
+import org.folio.dcb.domain.dto.DcbPickup;
+import org.folio.dcb.domain.dto.TransactionStatusResponseList;
 import org.folio.dcb.domain.entity.TransactionEntity;
 import org.folio.dcb.domain.dto.DcbTransaction;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
+import java.util.List;
 
 @Component
 public class TransactionMapper {
@@ -31,6 +37,54 @@ public class TransactionMapper {
       .patronGroup(patron.getGroup())
 
       .role(dcbTransaction.getRole())
+      .build();
+  }
+
+  public List<TransactionStatusResponseList> mapToDto(Page<TransactionEntity> transactionEntityPage) {
+    var transactionList = transactionEntityPage.getContent();
+    return transactionList
+      .stream()
+      .map(transactionEntity -> TransactionStatusResponseList
+        .builder()
+        .id(transactionEntity.getId())
+        .pickup(mapTransactionEntityToDcbPickup(transactionEntity))
+        .item(mapTransactionEntityToDcbItem(transactionEntity))
+        .patron(mapTransactionEntityToDcbPatron(transactionEntity))
+        .status(TransactionStatusResponseList.StatusEnum.fromValue
+          (transactionEntity.getStatus().getValue()))
+        .role(TransactionStatusResponseList.RoleEnum.fromValue
+          (transactionEntity.getRole().getValue()))
+        .build())
+      .toList();
+
+  }
+
+  public DcbItem mapTransactionEntityToDcbItem(TransactionEntity transactionEntity) {
+    return DcbItem
+      .builder()
+      .id(transactionEntity.getItemId())
+      .title(transactionEntity.getItemTitle())
+      .barcode(transactionEntity.getItemBarcode())
+      .materialType(transactionEntity.getMaterialType())
+      .lendingLibraryCode(transactionEntity.getLendingLibraryCode())
+      .build();
+  }
+
+  public DcbPatron mapTransactionEntityToDcbPatron(TransactionEntity transactionEntity) {
+    return DcbPatron
+      .builder()
+      .id(transactionEntity.getPatronId())
+      .group(transactionEntity.getPatronGroup())
+      .barcode(transactionEntity.getPatronBarcode())
+      .build();
+  }
+
+  public DcbPickup mapTransactionEntityToDcbPickup(TransactionEntity transactionEntity) {
+    return DcbPickup
+      .builder()
+      .servicePointId(transactionEntity.getServicePointId())
+      .servicePointName(transactionEntity.getServicePointName())
+      .libraryCode(transactionEntity.getPickupLibraryCode())
       .build();
   }
 

--- a/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
+++ b/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
@@ -1,6 +1,5 @@
 package org.folio.dcb.domain.mapper;
 
-import lombok.RequiredArgsConstructor;
 import org.folio.dcb.domain.dto.DcbItem;
 import org.folio.dcb.domain.dto.DcbPatron;
 import org.folio.dcb.domain.dto.DcbPickup;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-@RequiredArgsConstructor
 public class TransactionMapper {
 
   public TransactionEntity mapToEntity(String transactionId, DcbTransaction dcbTransaction) {

--- a/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
+++ b/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
@@ -1,7 +1,5 @@
 package org.folio.dcb.domain.mapper;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.folio.dcb.domain.dto.DcbItem;
 import org.folio.dcb.domain.dto.DcbPatron;
@@ -10,6 +8,7 @@ import org.folio.dcb.domain.dto.TransactionStatusResponseList;
 import org.folio.dcb.domain.entity.TransactionAuditEntity;
 import org.folio.dcb.domain.entity.TransactionEntity;
 import org.folio.dcb.domain.dto.DcbTransaction;
+import org.folio.dcb.utils.JsonUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import java.util.List;
@@ -17,8 +16,6 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class TransactionMapper {
-
-  private final ObjectMapper objectMapper;
 
   public TransactionEntity mapToEntity(String transactionId, DcbTransaction dcbTransaction) {
     if(dcbTransaction == null || dcbTransaction.getItem() == null || dcbTransaction.getPatron() == null || dcbTransaction.getPickup() == null) {
@@ -51,7 +48,7 @@ public class TransactionMapper {
     var transactionList = transactionAuditEntityPage.getContent();
     return transactionList
       .stream()
-      .map(transactionAuditEntity -> getTransactionEntity(objectMapper, transactionAuditEntity))
+      .map(transactionAuditEntity -> JsonUtils.jsonToObject(transactionAuditEntity.getAfter(), TransactionEntity.class))
       .map(transactionEntity -> TransactionStatusResponseList
         .builder()
         .id(transactionEntity.getId())
@@ -65,14 +62,6 @@ public class TransactionMapper {
         .build())
       .toList();
 
-  }
-
-  private TransactionEntity getTransactionEntity(ObjectMapper mapper, TransactionAuditEntity transactionAuditEntity) {
-    try {
-      return mapper.readValue(transactionAuditEntity.getAfter(), TransactionEntity.class);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public DcbItem mapTransactionEntityToDcbItem(TransactionEntity transactionEntity) {

--- a/src/main/java/org/folio/dcb/repository/TransactionAuditRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionAuditRepository.java
@@ -1,11 +1,14 @@
 package org.folio.dcb.repository;
 
 import org.folio.dcb.domain.entity.TransactionAuditEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +18,10 @@ public interface TransactionAuditRepository extends JpaRepository<TransactionAud
     "WHERE transaction_id = :trnId " +
     "and created_date = (SELECT MAX(created_date) FROM transactions_audit WHERE transaction_id = :trnId);", nativeQuery = true)
   Optional<TransactionAuditEntity> findLatestTransactionAuditEntityByDcbTransactionId(@Param("trnId") String trnId);
+
+  @Query(value = "SELECT * FROM transactions t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
+    countQuery = "SELECT COUNT(*) FROM transactions t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
+    nativeQuery = true)
+  Page<TransactionAuditEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
+
 }

--- a/src/main/java/org/folio/dcb/repository/TransactionAuditRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionAuditRepository.java
@@ -19,9 +19,9 @@ public interface TransactionAuditRepository extends JpaRepository<TransactionAud
     "and created_date = (SELECT MAX(created_date) FROM transactions_audit WHERE transaction_id = :trnId);", nativeQuery = true)
   Optional<TransactionAuditEntity> findLatestTransactionAuditEntityByDcbTransactionId(@Param("trnId") String trnId);
 
-  @Query(value = "SELECT * FROM transactions_audit t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
-    countQuery = "SELECT COUNT(*) FROM transactions_audit t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
+  @Query(value = "SELECT * FROM transactions_audit t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate AND t.action = 'UPDATE'",
+    countQuery = "SELECT COUNT(*) FROM transactions_audit t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate AND t.action = 'UPDATE'",
     nativeQuery = true)
-  Page<TransactionAuditEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
+  Page<TransactionAuditEntity> findUpdatedTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
 
 }

--- a/src/main/java/org/folio/dcb/repository/TransactionAuditRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionAuditRepository.java
@@ -19,8 +19,8 @@ public interface TransactionAuditRepository extends JpaRepository<TransactionAud
     "and created_date = (SELECT MAX(created_date) FROM transactions_audit WHERE transaction_id = :trnId);", nativeQuery = true)
   Optional<TransactionAuditEntity> findLatestTransactionAuditEntityByDcbTransactionId(@Param("trnId") String trnId);
 
-  @Query(value = "SELECT * FROM transactions t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
-    countQuery = "SELECT COUNT(*) FROM transactions t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
+  @Query(value = "SELECT * FROM transactions_audit t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
+    countQuery = "SELECT COUNT(*) FROM transactions_audit t WHERE t.created_date >= :fromDate AND t.created_date <= :toDate",
     nativeQuery = true)
   Page<TransactionAuditEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
 

--- a/src/main/java/org/folio/dcb/repository/TransactionRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionRepository.java
@@ -24,10 +24,10 @@ public interface TransactionRepository extends JpaRepository<TransactionEntity, 
   @Query(value = "SELECT * FROM transactions where request_id = :requestId AND status != 'CLOSED'", nativeQuery = true)
   Optional<TransactionEntity> findTransactionByRequestIdAndStatusNotInClosed(@Param("requestId") UUID itemId);
 
-  @Query("SELECT COUNT(t) FROM transactions t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
+  @Query("SELECT COUNT(t) FROM TransactionEntity t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
   int countTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate);
 
-  @Query("SELECT t FROM transactions t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
+  @Query("SELECT t FROM TransactionEntity t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
   Page<TransactionEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
 
 }

--- a/src/main/java/org/folio/dcb/repository/TransactionRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionRepository.java
@@ -1,11 +1,14 @@
 package org.folio.dcb.repository;
 
 import org.folio.dcb.domain.entity.TransactionEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -20,5 +23,11 @@ public interface TransactionRepository extends JpaRepository<TransactionEntity, 
 
   @Query(value = "SELECT * FROM transactions where request_id = :requestId AND status != 'CLOSED'", nativeQuery = true)
   Optional<TransactionEntity> findTransactionByRequestIdAndStatusNotInClosed(@Param("requestId") UUID itemId);
+
+  @Query("SELECT COUNT(t) FROM transactions t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
+  int countTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate);
+
+  @Query("SELECT t FROM transactions t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
+  Page<TransactionEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
 
 }

--- a/src/main/java/org/folio/dcb/repository/TransactionRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionRepository.java
@@ -24,10 +24,9 @@ public interface TransactionRepository extends JpaRepository<TransactionEntity, 
   @Query(value = "SELECT * FROM transactions where request_id = :requestId AND status != 'CLOSED'", nativeQuery = true)
   Optional<TransactionEntity> findTransactionByRequestIdAndStatusNotInClosed(@Param("requestId") UUID itemId);
 
-  @Query("SELECT COUNT(t) FROM TransactionEntity t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
-  int countTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate);
-
-  @Query("SELECT t FROM TransactionEntity t WHERE t.updatedDate >= :fromDate AND t.updatedDate <= :toDate")
+  @Query(value = "SELECT * FROM transactions t WHERE t.updated_date >= :fromDate AND t.updated_date <= :toDate",
+    countQuery = "SELECT COUNT(*) FROM transactions t WHERE t.updated_date >= :fromDate AND t.updated_date <= :toDate",
+    nativeQuery = true)
   Page<TransactionEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
 
 }

--- a/src/main/java/org/folio/dcb/repository/TransactionRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionRepository.java
@@ -1,14 +1,11 @@
 package org.folio.dcb.repository;
 
 import org.folio.dcb.domain.entity.TransactionEntity;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,10 +20,5 @@ public interface TransactionRepository extends JpaRepository<TransactionEntity, 
 
   @Query(value = "SELECT * FROM transactions where request_id = :requestId AND status != 'CLOSED'", nativeQuery = true)
   Optional<TransactionEntity> findTransactionByRequestIdAndStatusNotInClosed(@Param("requestId") UUID itemId);
-
-  @Query(value = "SELECT * FROM transactions t WHERE t.updated_date >= :fromDate AND t.updated_date <= :toDate",
-    countQuery = "SELECT COUNT(*) FROM transactions t WHERE t.updated_date >= :fromDate AND t.updated_date <= :toDate",
-    nativeQuery = true)
-  Page<TransactionEntity> findTransactionsByDateRange(OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);
 
 }

--- a/src/main/java/org/folio/dcb/service/TransactionsService.java
+++ b/src/main/java/org/folio/dcb/service/TransactionsService.java
@@ -3,6 +3,8 @@ package org.folio.dcb.service;
 import org.folio.dcb.domain.dto.DcbTransaction;
 import org.folio.dcb.domain.dto.TransactionStatus;
 import org.folio.dcb.domain.dto.TransactionStatusResponse;
+import org.folio.dcb.domain.dto.TransactionStatusResponseCollection;
+import java.time.OffsetDateTime;
 
 public interface TransactionsService {
   /**
@@ -14,4 +16,6 @@ public interface TransactionsService {
   TransactionStatusResponse createCirculationRequest(String dcbTransactionId, DcbTransaction dcbTransaction);
   TransactionStatusResponse updateTransactionStatus(String dcbTransactionId, TransactionStatus transactionStatus);
   TransactionStatusResponse getTransactionStatusById(String dcbTransactionId);
+  TransactionStatusResponseCollection getTransactionStatusList(OffsetDateTime fromDate, OffsetDateTime toDate, Integer pageNumber, Integer pageSize);
+
   }

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -93,12 +93,12 @@ public class TransactionsServiceImpl implements TransactionsService {
     log.info("getTransactionStatusList:: fromDate {}, toDate {}, pageNumber {}, pageSize {}",
       fromDate, toDate, pageNumber, pageSize);
     var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("updatedDate"));
-    var transactionStatusResponseList= transactionMapper.mapToDto(transactionRepository.findTransactionsByDateRange(fromDate, toDate, pageable));
-    var totalRecordCount = transactionRepository.countTransactionsByDateRange(fromDate, toDate);
+    var transactionEntityPage= transactionRepository.findTransactionsByDateRange(fromDate, toDate, pageable);
+    var transactionStatusResponseList= transactionMapper.mapToDto(transactionEntityPage);
     return TransactionStatusResponseCollection
       .builder()
       .transactions(transactionStatusResponseList)
-      .totalRecords(totalRecordCount)
+      .totalRecords((int)transactionEntityPage.getTotalElements())
       .build();
   }
 

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -92,7 +92,7 @@ public class TransactionsServiceImpl implements TransactionsService {
   public TransactionStatusResponseCollection getTransactionStatusList(OffsetDateTime fromDate, OffsetDateTime toDate, Integer pageNumber, Integer pageSize) {
     log.info("getTransactionStatusList:: fromDate {}, toDate {}, pageNumber {}, pageSize {}",
       fromDate, toDate, pageNumber, pageSize);
-    var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("updatedDate"));
+    var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("updated_Date"));
     var transactionEntityPage= transactionRepository.findTransactionsByDateRange(fromDate, toDate, pageable);
     var transactionStatusResponseList= transactionMapper.mapToDto(transactionEntityPage);
     return TransactionStatusResponseCollection

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -94,7 +94,7 @@ public class TransactionsServiceImpl implements TransactionsService {
   public TransactionStatusResponseCollection getTransactionStatusList(OffsetDateTime fromDate, OffsetDateTime toDate, Integer pageNumber, Integer pageSize) {
     log.info("getTransactionStatusList:: fromDate {}, toDate {}, pageNumber {}, pageSize {}",
       fromDate, toDate, pageNumber, pageSize);
-    var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("updated_Date"));
+    var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("created_Date"));
     var transactionAuditEntityPage= transactionAuditRepository.findTransactionsByDateRange(fromDate, toDate, pageable);
     var transactionStatusResponseList= transactionMapper.mapToDto(transactionAuditEntityPage);
     return TransactionStatusResponseCollection

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -98,7 +98,7 @@ public class TransactionsServiceImpl implements TransactionsService {
     var transactionAuditEntityPage= transactionAuditRepository.findUpdatedTransactionsByDateRange(fromDate, toDate, pageable);
     var transactionStatusResponseList= transactionMapper.mapToDto(transactionAuditEntityPage);
     var totalRecords = (int)transactionAuditEntityPage.getTotalElements();
-    var maxPageNumber = pageSize >= totalRecords ? 0 : (int) Math.floor((double) totalRecords / pageSize) - 1;
+    var maxPageNumber = pageSize >= totalRecords ? 0 : (int) Math.ceil((double) totalRecords / pageSize) - 1;
     return TransactionStatusResponseCollection
       .builder()
       .transactions(transactionStatusResponseList)

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -95,7 +95,7 @@ public class TransactionsServiceImpl implements TransactionsService {
     log.info("getTransactionStatusList:: fromDate {}, toDate {}, pageNumber {}, pageSize {}",
       fromDate, toDate, pageNumber, pageSize);
     var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("created_Date"));
-    var transactionAuditEntityPage= transactionAuditRepository.findTransactionsByDateRange(fromDate, toDate, pageable);
+    var transactionAuditEntityPage= transactionAuditRepository.findUpdatedTransactionsByDateRange(fromDate, toDate, pageable);
     var transactionStatusResponseList= transactionMapper.mapToDto(transactionAuditEntityPage);
     return TransactionStatusResponseCollection
       .builder()

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -10,6 +10,7 @@ import org.folio.dcb.domain.entity.TransactionEntity;
 import org.folio.dcb.domain.mapper.TransactionMapper;
 import org.folio.dcb.exception.ResourceAlreadyExistException;
 import org.folio.dcb.exception.StatusException;
+import org.folio.dcb.repository.TransactionAuditRepository;
 import org.folio.dcb.repository.TransactionRepository;
 import org.folio.dcb.service.LibraryService;
 import org.folio.dcb.service.StatusProcessorService;
@@ -37,6 +38,7 @@ public class TransactionsServiceImpl implements TransactionsService {
   private final TransactionRepository transactionRepository;
   private final StatusProcessorService statusProcessorService;
   private final TransactionMapper transactionMapper;
+  private final TransactionAuditRepository transactionAuditRepository;
 
   @Override
   public TransactionStatusResponse createCirculationRequest(String dcbTransactionId, DcbTransaction dcbTransaction) {
@@ -93,12 +95,12 @@ public class TransactionsServiceImpl implements TransactionsService {
     log.info("getTransactionStatusList:: fromDate {}, toDate {}, pageNumber {}, pageSize {}",
       fromDate, toDate, pageNumber, pageSize);
     var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("updated_Date"));
-    var transactionEntityPage= transactionRepository.findTransactionsByDateRange(fromDate, toDate, pageable);
-    var transactionStatusResponseList= transactionMapper.mapToDto(transactionEntityPage);
+    var transactionAuditEntityPage= transactionAuditRepository.findTransactionsByDateRange(fromDate, toDate, pageable);
+    var transactionStatusResponseList= transactionMapper.mapToDto(transactionAuditEntityPage);
     return TransactionStatusResponseCollection
       .builder()
       .transactions(transactionStatusResponseList)
-      .totalRecords((int)transactionEntityPage.getTotalElements())
+      .totalRecords((int)transactionAuditEntityPage.getTotalElements())
       .build();
   }
 

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -98,13 +98,14 @@ public class TransactionsServiceImpl implements TransactionsService {
     var transactionAuditEntityPage= transactionAuditRepository.findUpdatedTransactionsByDateRange(fromDate, toDate, pageable);
     var transactionStatusResponseList= transactionMapper.mapToDto(transactionAuditEntityPage);
     var totalRecords = (int)transactionAuditEntityPage.getTotalElements();
+    var maxPageNumber = pageSize >= totalRecords ? 0 : (int) Math.floor((double) totalRecords / pageSize) - 1;
     return TransactionStatusResponseCollection
       .builder()
       .transactions(transactionStatusResponseList)
       .totalRecords(totalRecords)
       .currentPageNumber(pageNumber)
       .currentPageSize(pageSize)
-      .maximumPageNumber((int) Math.floor((double) totalRecords / pageSize) - 1)
+      .maximumPageNumber(maxPageNumber)
       .build();
   }
 

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -104,7 +104,7 @@ public class TransactionsServiceImpl implements TransactionsService {
       .totalRecords(totalRecords)
       .currentPageNumber(pageNumber)
       .currentPageSize(pageSize)
-      .maximumPageNumber((int) Math.ceil((double) totalRecords / pageSize))
+      .maximumPageNumber((int) Math.floor((double) totalRecords / pageSize) - 1)
       .build();
   }
 

--- a/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/TransactionsServiceImpl.java
@@ -97,10 +97,14 @@ public class TransactionsServiceImpl implements TransactionsService {
     var pageable = PageRequest.of(pageNumber, pageSize, Sort.by("created_Date"));
     var transactionAuditEntityPage= transactionAuditRepository.findUpdatedTransactionsByDateRange(fromDate, toDate, pageable);
     var transactionStatusResponseList= transactionMapper.mapToDto(transactionAuditEntityPage);
+    var totalRecords = (int)transactionAuditEntityPage.getTotalElements();
     return TransactionStatusResponseCollection
       .builder()
       .transactions(transactionStatusResponseList)
-      .totalRecords((int)transactionAuditEntityPage.getTotalElements())
+      .totalRecords(totalRecords)
+      .currentPageNumber(pageNumber)
+      .currentPageSize(pageSize)
+      .maximumPageNumber((int) Math.ceil((double) totalRecords / pageSize))
       .build();
   }
 

--- a/src/main/java/org/folio/dcb/utils/JsonUtils.java
+++ b/src/main/java/org/folio/dcb/utils/JsonUtils.java
@@ -1,0 +1,23 @@
+package org.folio.dcb.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.experimental.UtilityClass;
+import lombok.extern.log4j.Log4j2;
+
+@UtilityClass
+@Log4j2
+public class JsonUtils {
+  public static final String DESERIALIZATION_FAILURE = "Failed to deserialize json string";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public static <T> T jsonToObject(String jsonString, Class<T> classToDeserialize) {
+    try {
+      return OBJECT_MAPPER.readValue(jsonString, classToDeserialize);
+    } catch (JsonProcessingException ex) {
+      log.info(DESERIALIZATION_FAILURE + ex);
+      throw new IllegalArgumentException(DESERIALIZATION_FAILURE + ex.getMessage());
+    }
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
-    show-sql: true
+    show-sql: false
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/changelog-master.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,12 +21,12 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
-    show-sql: false
+    show-sql: true
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/changelog-master.xml
   jackson:
-    default-property-inclusion: non_empty
+    default-property-inclusion: non_null
     deserialization:
       fail-on-unknown-properties: false
       accept-single-value-as-array: true

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -8,5 +8,6 @@
   <include file="changes/create-audit-table.xml" relativeToChangelogFile="true"/>
   <include file="changes/add-request-to-transaction.xml" relativeToChangelogFile="true"/>
   <include file="changes/set-optional-fields-nullable.xml" relativeToChangelogFile="true"/>
+  <include file="changes/alter-date-datatype.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/alter-date-datatype.xml
+++ b/src/main/resources/db/changelog/changes/alter-date-datatype.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet id="alterDateColumnsType" author="vignesh">
+    <sql>
+      <![CDATA[
+      ALTER TABLE transactions ALTER COLUMN created_date TYPE timestamp with time zone;
+      ALTER TABLE transactions ALTER COLUMN updated_date TYPE timestamp with time zone;
+      ]]>
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/alter-date-datatype.xml
+++ b/src/main/resources/db/changelog/changes/alter-date-datatype.xml
@@ -9,6 +9,7 @@
       <![CDATA[
       ALTER TABLE transactions ALTER COLUMN created_date TYPE timestamp with time zone;
       ALTER TABLE transactions ALTER COLUMN updated_date TYPE timestamp with time zone;
+      ALTER TABLE transactions_audit ALTER COLUMN created_date TYPE timestamp with time zone;
       ]]>
     </sql>
   </changeSet>

--- a/src/main/resources/swagger.api/dcb_transaction.yaml
+++ b/src/main/resources/swagger.api/dcb_transaction.yaml
@@ -166,7 +166,7 @@ components:
       schema:
         type: string
         format: date-time
-      required: false
+      required: true
     pageNumber:
       in: query
       name: pageNumber

--- a/src/main/resources/swagger.api/dcb_transaction.yaml
+++ b/src/main/resources/swagger.api/dcb_transaction.yaml
@@ -57,6 +57,24 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /transactions/status:
+    parameters:
+      - $ref: '#/components/parameters/fromDate'
+      - $ref: '#/components/parameters/toDate'
+      - $ref: '#/components/parameters/pageNumber'
+      - $ref: '#/components/parameters/pageSize'
+    get:
+      description: Get a list of updated transactions between from date and to date with optional filtering and pagination
+      operationId: getTransactionStatusList
+      tags:
+        - circulation
+      responses:
+        '200':
+          $ref: '#/components/responses/TransactionStatusResponseCollection'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   requestBodies:
     TransactionStatusBody:
@@ -85,6 +103,12 @@ components:
         application/json:
           schema:
             $ref: "schemas/transactionStatusResponse.yaml#/TransactionStatusResponse"
+    TransactionStatusResponseCollection:
+      description: List of TransactionResponse object
+      content:
+        application/json:
+          schema:
+            $ref: "schemas/transactionStatusResponse.yaml#/TransactionStatusResponseCollection"
     NotFound:
       description: Resource not found
       content:
@@ -127,6 +151,42 @@ components:
       schema:
         type: string
       required: true
+    fromDate:
+      in: query
+      name: fromDate
+      description: Start date for filtering transactions
+      schema:
+        type: string
+        format: date-time
+      required: true
+    toDate:
+      in: query
+      name: toDate
+      description: End date for filtering transactions
+      schema:
+        type: string
+        format: date-time
+      required: false
+    pageNumber:
+      in: query
+      name: pageNumber
+      description: Page number for pagination (optional)
+      schema:
+        type: integer
+        default: 0
+        minimum: 0
+        maximum: 2147483647
+      required: false
+    pageSize:
+      in: query
+      name: pageSize
+      description: Number of items per page (optional)
+      schema:
+        type: integer
+        default: 1000
+        minimum: 1
+        maximum: 2147483647
+      required: false
   schemas:
     InventoryItem:
       $ref: 'schemas/InventoryItem.yaml#/InventoryItem'

--- a/src/main/resources/swagger.api/schemas/transactionStatusResponse.yaml
+++ b/src/main/resources/swagger.api/schemas/transactionStatusResponse.yaml
@@ -19,5 +19,14 @@ TransactionStatusResponseCollection:
       description: "transaction collection"
       items:
         $ref: 'transactionStatusResponse.yaml#/TransactionStatusResponseList'
+    currentPageNumber:
+      type: integer
+      description: "Page Number of the current request"
+    currentPageSize:
+      type: integer
+      description: "Number of items fetched"
+    maximumPageNumber:
+      type: integer
+      description: "maximum page Number to fetch total records with current page size"
     totalRecords:
       type: integer

--- a/src/main/resources/swagger.api/schemas/transactionStatusResponse.yaml
+++ b/src/main/resources/swagger.api/schemas/transactionStatusResponse.yaml
@@ -29,4 +29,5 @@ TransactionStatusResponseCollection:
       type: integer
       description: "maximum page Number to fetch total records with current page size"
     totalRecords:
+      description: "total number of records which are matched to the current search"
       type: integer

--- a/src/main/resources/swagger.api/schemas/transactionStatusResponse.yaml
+++ b/src/main/resources/swagger.api/schemas/transactionStatusResponse.yaml
@@ -2,3 +2,22 @@ TransactionStatusResponse:
   allOf:
     - $ref: 'transactionStatus.yaml#/TransactionStatus'
     - $ref: 'dcbTransaction.yaml#/DcbTransaction'
+
+TransactionStatusResponseList:
+  properties:
+    id:
+      description: "Unique identifier of a transaction"
+      $ref: "uuid.yaml"
+  allOf:
+    - $ref: 'transactionStatusResponse.yaml#/TransactionStatusResponse'
+
+TransactionStatusResponseCollection:
+  type: object
+  properties:
+    transactions:
+      type: array
+      description: "transaction collection"
+      items:
+        $ref: 'transactionStatusResponse.yaml#/TransactionStatusResponseList'
+    totalRecords:
+      type: integer

--- a/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
+++ b/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
@@ -930,7 +930,7 @@ class TransactionApiControllerTest extends BaseIT {
       .andExpect(jsonPath("$.transactions[*].status",
         containsInRelativeOrder("AWAITING_PICKUP", "ITEM_CHECKED_OUT", "ITEM_CHECKED_IN", "CLOSED")));
 
-    // Now try to get all the records from startDate1 to endDate2 with pageSize
+    // Now try to get all the records from startDate1 to endDate2 without pageSize(default pageSize)
     this.mockMvc.perform(
         get("/transactions/status")
           .headers(defaultHeaders())

--- a/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
+++ b/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
@@ -855,9 +855,10 @@ class TransactionApiControllerTest extends BaseIT {
 
   @Test
   void getTransactionStatusUpdateListTest() throws Exception {
-    removeExistedTransactionFromDbIfSoExists();
     var startDate1 = OffsetDateTime.now(ZoneOffset.UTC);
     var dcbTransaction = createDcbTransactionByRole(BORROWER);
+    removeExistedTransactionFromDbIfSoExists();
+    removeExistingTransactionsByItemId(dcbTransaction.getItem().getId());
 
     // Creating new transaction
     this.mockMvc.perform(


### PR DESCRIPTION
## Purpose
The purpose of the PR is to implement [MODDCB-98](https://folio-org.atlassian.net/browse/MODDCB-98)

## Approach
We have introduced new API which support from date and to date and optional pagination parameters. This api will query the audit table and return the list of updated transaction with in the from and to date range. As we are looking into audit table, this api will always return same data for the time range.  We have also returned total records which is nothing but the total number of records which updated in the time frame irrespective of pagination and maxPageNumber which is nothing but total number of pages required to fetch the total records with currentPageSize. Also, altered the existing date field to timestamp with time zone in DB and made necessary changes in code so that it will support offSetDateTime in the request.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
