### PR TITLE
MODDCB-111: Allow manual transaction status change CREATED -> OPEN

### DIFF
--- a/src/main/java/org/folio/dcb/service/StatusProcessorService.java
+++ b/src/main/java/org/folio/dcb/service/StatusProcessorService.java
@@ -28,7 +28,7 @@ public class StatusProcessorService {
     StatusProcessor checkInProcessor = new StatusProcessor(ITEM_CHECKED_OUT, ITEM_CHECKED_IN, false, closeProcessor);
     StatusProcessor checkoutProcessor = new StatusProcessor(AWAITING_PICKUP, ITEM_CHECKED_OUT, false, checkInProcessor);
     StatusProcessor awaitingPickupProcessor = new StatusProcessor(OPEN, AWAITING_PICKUP, false, checkoutProcessor);
-    StatusProcessor openProcessor = new StatusProcessor(CREATED, OPEN, true, awaitingPickupProcessor);
+    StatusProcessor openProcessor = new StatusProcessor(CREATED, OPEN, false, awaitingPickupProcessor);
     startChain.setChain(openProcessor);
     var statuses = process(startChain, fromStatus, toStatus);
     log.info("lendingChainProcessor:: Following statuses needs to be transitioned {} ", statuses);

--- a/src/main/java/org/folio/dcb/service/impl/LendingLibraryServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/LendingLibraryServiceImpl.java
@@ -17,6 +17,7 @@ import org.folio.dcb.service.UserService;
 import org.springframework.stereotype.Service;
 
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.AWAITING_PICKUP;
+import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CREATED;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.ITEM_CHECKED_IN;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.ITEM_CHECKED_OUT;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.OPEN;
@@ -60,7 +61,9 @@ public class LendingLibraryServiceImpl implements LibraryService {
     log.debug("updateTransactionStatus:: Updating dcbTransaction {} to status {} ", dcbTransaction, transactionStatus);
     var currentStatus = dcbTransaction.getStatus();
     var requestedStatus = transactionStatus.getStatus();
-    if (OPEN == currentStatus && AWAITING_PICKUP == requestedStatus) {
+    if (CREATED == currentStatus && OPEN == requestedStatus) {
+      updateTransactionEntity(dcbTransaction, requestedStatus);
+    } else if (OPEN == currentStatus && AWAITING_PICKUP == requestedStatus) {
       log.info("updateTransactionStatus:: Checking in item by barcode: {} ", dcbTransaction.getItemBarcode());
       circulationService.checkInByBarcode(dcbTransaction);
       updateTransactionEntity(dcbTransaction, requestedStatus);

--- a/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
+++ b/src/test/java/org/folio/dcb/controller/TransactionApiControllerTest.java
@@ -592,6 +592,26 @@ class TransactionApiControllerTest extends BaseIT {
   }
 
   @Test
+  void lenderTransactionStatusUpdateFromCreatedToOpen() throws Exception {
+    var transactionID = UUID.randomUUID().toString();
+    var dcbTransaction = createTransactionEntity();
+    dcbTransaction.setStatus(TransactionStatus.StatusEnum.CREATED);
+    dcbTransaction.setRole(LENDER);
+    dcbTransaction.setId(transactionID);
+
+    systemUserScopedExecutionService.executeAsyncSystemUserScoped(TENANT, () -> transactionRepository.save(dcbTransaction));
+
+    this.mockMvc.perform(
+        put("/transactions/" + transactionID + "/status")
+          .content(asJsonString(createTransactionStatus(TransactionStatus.StatusEnum.OPEN)))
+          .headers(defaultHeaders())
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.status").value("OPEN"));
+  }
+
+  @Test
   void transactionStatusUpdateFromItemCheckedOutToItemCheckedIn() throws Exception {
     var transactionID = UUID.randomUUID().toString();
     var dcbTransaction = createTransactionEntity();

--- a/src/test/java/org/folio/dcb/service/StatusProcessorServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/StatusProcessorServiceTest.java
@@ -45,12 +45,6 @@ class StatusProcessorServiceTest {
 
   @Test
   void lendingChainProcessorErrorTest() {
-    assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.AWAITING_PICKUP));
-
-    assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.ITEM_CHECKED_OUT));
-
-    assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.ITEM_CHECKED_IN));
-
     assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.CLOSED));
 
     assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.CREATED));

--- a/src/test/java/org/folio/dcb/service/StatusProcessorServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/StatusProcessorServiceTest.java
@@ -45,8 +45,6 @@ class StatusProcessorServiceTest {
 
   @Test
   void lendingChainProcessorErrorTest() {
-    assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.OPEN));
-
     assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.AWAITING_PICKUP));
 
     assertThrows(StatusException.class, () -> statusProcessorService.lendingChainProcessor(TransactionStatus.StatusEnum.CREATED, TransactionStatus.StatusEnum.ITEM_CHECKED_OUT));


### PR DESCRIPTION
## Purpose
Whenever mod-tlr creates a secondary ECS request as TLR Hold, the requested item ID becomes known not during request creation, but when an item of the requested instance is checked-in in lending tenant. This means that mod-tlr can create DCB transactions for such ECS request only after check-in, not immediately when request is created. This also means that the status of the lending DCB transaction will not be changed from CREATED to OPEN automatically. This transition has to be performed manually, but currently it is not allowed for lending transactions. This must be changed, and changing status of the lending transactions from OPEN to CREATED must be allowed.

[MODDCB-111](https://folio-org.atlassian.net/browse/MODDCB-111)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
