### PR TITLE
MODDCB-143 Adding missed interface dependency in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -65,6 +65,10 @@
     {
       "id": "calendar",
       "version": "5.0"
+    },
+    {
+      "id": "cancellation-reason-storage",
+      "version": "1.2"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
The purpose of the PR is to fix MODDCB-143

## Approach
Added the missed interface dependency reported in the jira.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
