### PR TITLE
MODDCB-145 Fixing space issue in servicePointName

### DIFF
--- a/src/main/java/org/folio/dcb/service/impl/ServicePointServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/ServicePointServiceImpl.java
@@ -9,6 +9,7 @@ import org.folio.dcb.domain.dto.HoldShelfExpiryPeriod;
 import org.folio.dcb.domain.dto.ServicePointRequest;
 import org.folio.dcb.service.CalendarService;
 import org.folio.dcb.service.ServicePointService;
+import org.folio.util.StringUtil;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,7 +27,7 @@ public class ServicePointServiceImpl implements ServicePointService {
     String servicePointName = getServicePointName(pickupServicePoint.getLibraryCode(),
       pickupServicePoint.getServicePointName());
     var servicePointRequestList = servicePointClient
-      .getServicePointByName(servicePointName).getResult();
+      .getServicePointByName(StringUtil.cqlEncode(servicePointName)).getResult();
     if (servicePointRequestList.isEmpty()) {
       String servicePointId = UUID.randomUUID().toString();
       String servicePointCode = getServicePointCode(pickupServicePoint.getLibraryCode(),

--- a/src/test/resources/mappings/inventory.json
+++ b/src/test/resources/mappings/inventory.json
@@ -198,7 +198,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/service-points?query=name==DCB_TestLibraryCode_TestServicePointCode"
+        "url": "/service-points?query=name==%22DCB_TestLibraryCode_TestServicePointCode%22"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix [MODDCB-145](https://folio-org.atlassian.net/browse/MODDCB-145)

## Approach
In the existing code, while we are trying to fetch the servicePoint by name we are not wrapping the name inside double quotes "" 

Hence we got the below error
`[[http://service-points?query=name==DCB_6cabb_Conception%20Abbey%20and%20Seminary%20College](http://service-points/?query=name==DCB_6cabb_Conception%20Abbey%20and%20Seminary%20College)] [InventoryServicePointClient#getServicePointByName(String)]: [org.folio.cql2pgjson.exception.QueryValidationException: cql.serverChoice requested, but no serverChoiceIndexes defined.]"
`

To fix this, we use the folio stringUtil library and encode the name so that the name will be wrapped into "".


#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
