### PR TITLE
explain dcb

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 ## Introduction
 
-APIs for managing dcb (direct consortial borrowing) transactions in folio.
+APIs for managing DCB (direct consortial borrowing) transactions in folio.
 
 ## API information
 


### PR DESCRIPTION
## Purpose
The abbreviation dcb is not explained. This makes it difficult for sysops to understand the purpose of the module.

## Approach
Explain what dcb means in the README.md.