### PR TITLE
MODDCB-208: Fix cql query for querying patron group by name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2.0.0-SNAPSHOT 2025-XX-XX
 * MODDCB-196: Allow patrons to request items from own library via DCB
+* MODDCB-208: Fix cql query for querying patron group by name [MODDCB-208](https://folio-org.atlassian.net/browse/MODDCB-208)
 
 ## v1.3.0 2025-03-13
 

--- a/src/main/java/org/folio/dcb/service/impl/PatronGroupServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/PatronGroupServiceImpl.java
@@ -19,12 +19,16 @@ public class PatronGroupServiceImpl implements PatronGroupService {
   public String fetchPatronGroupIdByName(String groupName) {
     log.debug("fetchPatronGroupIdByName:: Fetching patron group details with groupName {} ",
       groupName);
-    return groupClient.fetchGroupByName("group==" + groupName)
+    return groupClient.fetchGroupByName(queryByGroupName(groupName))
       .getUsergroups()
       .stream()
       .filter(group -> group.getGroup().equals(groupName))
       .findFirst()
       .map(UserGroup::getId)
       .orElseThrow(() -> new NotFoundException(String.format("Patron group not found with name %s ", groupName)));
+  }
+
+  private String queryByGroupName(String groupName) {
+    return "group==\"" + groupName + "\"";
   }
 }

--- a/src/main/java/org/folio/dcb/service/impl/PatronGroupServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/PatronGroupServiceImpl.java
@@ -19,7 +19,7 @@ public class PatronGroupServiceImpl implements PatronGroupService {
   public String fetchPatronGroupIdByName(String groupName) {
     log.debug("fetchPatronGroupIdByName:: Fetching patron group details with groupName {} ",
       groupName);
-    return groupClient.fetchGroupByName(queryByGroupName(groupName))
+    return groupClient.fetchGroupByName(getQueryByGroupName(groupName))
       .getUsergroups()
       .stream()
       .filter(group -> group.getGroup().equals(groupName))
@@ -28,7 +28,7 @@ public class PatronGroupServiceImpl implements PatronGroupService {
       .orElseThrow(() -> new NotFoundException(String.format("Patron group not found with name %s ", groupName)));
   }
 
-  private String queryByGroupName(String groupName) {
+  private String getQueryByGroupName(String groupName) {
     return "group==\"" + groupName + "\"";
   }
 }

--- a/src/test/java/org/folio/dcb/service/PatronGroupServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/PatronGroupServiceTest.java
@@ -29,8 +29,8 @@ class PatronGroupServiceTest {
     var userGroupCollection = createUserGroupCollection();
     when(groupClient.fetchGroupByName(any())).thenReturn(userGroupCollection);
     var response = patronGroupService.fetchPatronGroupIdByName("staff");
-    verify(groupClient).fetchGroupByName("group==staff");
-    assertEquals(userGroupCollection.getUsergroups().get(0).getId(), response);
+    verify(groupClient).fetchGroupByName("group==\"staff\"");
+    assertEquals(userGroupCollection.getUsergroups().getFirst().getId(), response);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
cql query parser fails to parse query with parentheses for patron group name

## Approach
escape the query value with quotation marks

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
[MODDCB-208](https://folio-org.atlassian.net/browse/MODDCB-208)
