### PR TITLE
MODDCB-187: Create Umbrella DCB Holding if it is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * MODDCB-208: Bump Spring Boot from 3.4.3 to 3.5.0 and update other dependencies
 * MODDCB-206: Populate locationCode for DCB Transaction API
 * MODDCB-216: Item Storage API version update from 10.1 to 11.0 [MODDCB-216](https://folio-org.atlassian.net/browse/MODDCB-216)
+* MODDCB-187: Create Umbrella DCB Inventory Holding if missing before using it [MODDCB-187](https://folio-org.atlassian.net/browse/MODDCB-187)
 
 ## v1.3.0 2025-03-13
 

--- a/src/main/java/org/folio/dcb/client/feign/HoldingsStorageClient.java
+++ b/src/main/java/org/folio/dcb/client/feign/HoldingsStorageClient.java
@@ -19,7 +19,7 @@ public interface HoldingsStorageClient {
   Holding findHolding(@PathVariable("holdingId") String holdingId);
 
   @PostMapping("/holdings")
-  void createHolding(@RequestBody Holding holding);
+  Holding createHolding(@RequestBody Holding holding);
 
   @Data
   @Builder

--- a/src/main/java/org/folio/dcb/exception/InventoryResourceOperationException.java
+++ b/src/main/java/org/folio/dcb/exception/InventoryResourceOperationException.java
@@ -1,0 +1,13 @@
+package org.folio.dcb.exception;
+
+public class InventoryResourceOperationException extends RuntimeException {
+
+  public InventoryResourceOperationException(String message, Throwable error) {
+    super(message, error);
+  }
+
+  public static InventoryResourceOperationException createInventoryResourceException(String resource, Throwable error) {
+    return new InventoryResourceOperationException("Failed to create %s".formatted(resource), error);
+  }
+
+}

--- a/src/main/java/org/folio/dcb/service/HoldingsService.java
+++ b/src/main/java/org/folio/dcb/service/HoldingsService.java
@@ -9,4 +9,10 @@ public interface HoldingsService {
    * @return InventoryHolding
    */
   HoldingsStorageClient.Holding fetchInventoryHoldingDetailsByHoldingId(String holdingId);
+
+  /**
+   * Get predefined DCB holding or create a new one if it does not exist.
+   * @return DCB Holding
+   */
+  HoldingsStorageClient.Holding fetchDcbHoldingOrCreateIfMissing();
 }

--- a/src/main/java/org/folio/dcb/service/impl/CirculationItemServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/CirculationItemServiceImpl.java
@@ -8,6 +8,7 @@ import org.folio.dcb.domain.dto.CirculationItem;
 import org.folio.dcb.domain.dto.DcbItem;
 import org.folio.dcb.domain.dto.ItemStatus;
 import org.folio.dcb.service.CirculationItemService;
+import org.folio.dcb.service.HoldingsService;
 import org.folio.dcb.service.ItemService;
 import org.folio.util.StringUtil;
 import org.springframework.stereotype.Service;
@@ -16,7 +17,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static org.folio.dcb.domain.dto.ItemStatus.NameEnum.IN_TRANSIT;
-import static org.folio.dcb.utils.DCBConstants.HOLDING_ID;
 import static org.folio.dcb.utils.DCBConstants.LOAN_TYPE_ID;
 import static org.folio.dcb.utils.DCBConstants.MATERIAL_TYPE_NAME_BOOK;
 
@@ -27,6 +27,7 @@ public class CirculationItemServiceImpl implements CirculationItemService {
 
   private final ItemService itemService;
   private final CirculationItemClient circulationItemClient;
+  private final HoldingsService holdingsService;
 
 
   @Override
@@ -58,6 +59,7 @@ public class CirculationItemServiceImpl implements CirculationItemService {
     //SetupDefaultMaterialTypeIfNotGiven
     String materialType = StringUtils.isBlank(item.getMaterialType()) ? MATERIAL_TYPE_NAME_BOOK : item.getMaterialType();
     var materialTypeId = itemService.fetchItemMaterialTypeIdByMaterialTypeName(materialType);
+    var dcbHolding = holdingsService.fetchDcbHoldingOrCreateIfMissing();
     var itemId = UUID.randomUUID().toString();
     CirculationItem circulationItem =
       CirculationItem.builder()
@@ -66,7 +68,7 @@ public class CirculationItemServiceImpl implements CirculationItemService {
         .status(ItemStatus.builder()
           .name(IN_TRANSIT)
           .build())
-        .holdingsRecordId(HOLDING_ID)
+        .holdingsRecordId(dcbHolding.getId())
         .instanceTitle(item.getTitle())
         .materialTypeId(materialTypeId)
         .permanentLoanTypeId(LOAN_TYPE_ID)

--- a/src/main/java/org/folio/dcb/service/impl/CustomTenantService.java
+++ b/src/main/java/org/folio/dcb/service/impl/CustomTenantService.java
@@ -242,9 +242,7 @@ public class CustomTenantService extends TenantService {
   }
 
   private void createHolding() {
-    var holding = holdingsService.fetchDcbHoldingOrCreateIfMissing();
-    log.info("DCB holding, id: {}, instanceId: {}, permanentLocationId: {}",
-      holding.getId(), holding.getInstanceId(), holding.getPermanentLocationId());
+    holdingsService.fetchDcbHoldingOrCreateIfMissing();
   }
 
   private void createCancellationReason(){

--- a/src/main/java/org/folio/dcb/service/impl/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/HoldingsServiceImpl.java
@@ -47,16 +47,7 @@ public class HoldingsServiceImpl implements HoldingsService {
   private HoldingsStorageClient.Holding createHolding() {
     try {
       log.debug("createHolding:: creating holding");
-      var holdingResourceList = holdingSourcesClient.querySourceByName(SOURCE);
-      String holdingResourceId;
-      if (holdingResourceList.getTotalRecords() == 0) {
-        var holdingResource = createHoldingSourceResource();
-        holdingResourceId = holdingResource.getId();
-      } else {
-        log.info("createHolding:: holdingResource record already exists");
-        holdingResourceId = holdingResourceList.getResult().getFirst().getId();
-      }
-
+      var holdingResourceId = getHoldingSourceId();
       HoldingsStorageClient.Holding holding = HoldingsStorageClient.Holding.builder()
         .id(HOLDING_ID)
         .instanceId(INSTANCE_ID)
@@ -72,6 +63,17 @@ public class HoldingsServiceImpl implements HoldingsService {
       log.error("createHolding:: Error while creating holding: {}", ex.getMessage());
       throw InventoryResourceOperationException.createInventoryResourceException("Holding", ex);
     }
+  }
+
+  private String getHoldingSourceId() {
+    log.debug("getHoldingSourceId:: Fetching holding source id for source {}", SOURCE);
+
+    var holdingResourceList = holdingSourcesClient.querySourceByName(SOURCE);
+    if (holdingResourceList.getTotalRecords() == 0) {
+      var holdingResource = createHoldingSourceResource();
+      return holdingResource.getId();
+    }
+    return holdingResourceList.getResult().getFirst().getId();
   }
 
   private HoldingSourcesClient.HoldingSource createHoldingSourceResource() {

--- a/src/main/java/org/folio/dcb/service/impl/HoldingsServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/HoldingsServiceImpl.java
@@ -1,9 +1,18 @@
 package org.folio.dcb.service.impl;
 
+import static org.folio.dcb.utils.DCBConstants.HOLDING_ID;
+import static org.folio.dcb.utils.DCBConstants.HOLDING_SOURCE;
+import static org.folio.dcb.utils.DCBConstants.INSTANCE_ID;
+import static org.folio.dcb.utils.DCBConstants.LOCATION_ID;
+import static org.folio.dcb.utils.DCBConstants.SOURCE;
+
 import feign.FeignException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.dcb.client.feign.HoldingSourcesClient;
 import org.folio.dcb.client.feign.HoldingsStorageClient;
+import org.folio.dcb.exception.InventoryResourceOperationException;
 import org.folio.dcb.service.HoldingsService;
 import org.folio.spring.exception.NotFoundException;
 import org.springframework.stereotype.Service;
@@ -14,6 +23,7 @@ import org.springframework.stereotype.Service;
 public class HoldingsServiceImpl implements HoldingsService {
 
   private final HoldingsStorageClient holdingsStorageClient;
+  private final HoldingSourcesClient holdingSourcesClient;
 
   @Override
   public HoldingsStorageClient.Holding fetchInventoryHoldingDetailsByHoldingId(String holdingsId) {
@@ -23,6 +33,55 @@ public class HoldingsServiceImpl implements HoldingsService {
     } catch (FeignException.NotFound ex) {
       throw new NotFoundException(String.format("Holdings not found for holdings id %s", holdingsId));
     }
+  }
+
+  @Override
+  public HoldingsStorageClient.Holding fetchDcbHoldingOrCreateIfMissing() {
+    try {
+      return holdingsStorageClient.findHolding(HOLDING_ID);
+    } catch (FeignException.NotFound ex) {
+      return createHolding();
+    }
+  }
+
+  private HoldingsStorageClient.Holding createHolding() {
+    try {
+      log.debug("createHolding:: creating holding");
+      var holdingResourceList = holdingSourcesClient.querySourceByName(SOURCE);
+      String holdingResourceId;
+      if (holdingResourceList.getTotalRecords() == 0) {
+        var holdingResource = createHoldingSourceResource();
+        holdingResourceId = holdingResource.getId();
+      } else {
+        log.info("createHolding:: holdingResource record already exists");
+        holdingResourceId = holdingResourceList.getResult().getFirst().getId();
+      }
+
+      HoldingsStorageClient.Holding holding = HoldingsStorageClient.Holding.builder()
+        .id(HOLDING_ID)
+        .instanceId(INSTANCE_ID)
+        .permanentLocationId(LOCATION_ID)
+        .sourceId(holdingResourceId)
+        .build();
+
+      var created = holdingsStorageClient.createHolding(holding);
+      log.info("createHolding:: holding created: {}", created.getId());
+
+      return created;
+    } catch (Exception ex) {
+      log.error("createHolding:: Error while creating holding: {}", ex.getMessage());
+      throw InventoryResourceOperationException.createInventoryResourceException("Holding", ex);
+    }
+  }
+
+  private HoldingSourcesClient.HoldingSource createHoldingSourceResource() {
+    log.info("createHoldingResource:: Creating a new Holding Record source");
+    return holdingSourcesClient.createHoldingsRecordSource(HoldingSourcesClient.HoldingSource
+      .builder()
+      .id(UUID.randomUUID().toString())
+      .name(SOURCE)
+      .source(HOLDING_SOURCE)
+      .build());
   }
 
 }

--- a/src/main/java/org/folio/dcb/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/dcb/service/impl/RequestServiceImpl.java
@@ -3,7 +3,6 @@ package org.folio.dcb.service.impl;
 import static org.folio.dcb.domain.dto.CirculationRequest.RequestTypeEnum.PAGE;
 import static org.folio.dcb.domain.dto.CirculationRequest.RequestTypeEnum.HOLD;
 import static org.folio.dcb.domain.dto.ItemStatus.NameEnum.AVAILABLE;
-import static org.folio.dcb.utils.DCBConstants.HOLDING_ID;
 import static org.folio.dcb.utils.DCBConstants.INSTANCE_ID;
 import static org.folio.dcb.utils.DCBConstants.holdItemStatus;
 
@@ -59,7 +58,8 @@ public class RequestServiceImpl implements RequestService {
   public CirculationRequest createHoldItemRequest(User user, DcbItem item, String pickupServicePointId) {
     log.debug("createHoldItemRequest:: creating a new hold request for userBarcode {} , itemBarcode {}",
       user.getBarcode(), item.getBarcode());
-    var circulationRequest = createCirculationRequest(HOLD, user, item, HOLDING_ID, INSTANCE_ID, pickupServicePointId);
+    var dcbHolding = holdingsService.fetchDcbHoldingOrCreateIfMissing();
+    var circulationRequest = createCirculationRequest(HOLD, user, item, dcbHolding.getId(), INSTANCE_ID, pickupServicePointId);
     return circulationClient.createRequest(circulationRequest);
   }
 

--- a/src/test/java/org/folio/dcb/service/CirculationItemServiceImplTest.java
+++ b/src/test/java/org/folio/dcb/service/CirculationItemServiceImplTest.java
@@ -1,0 +1,84 @@
+package org.folio.dcb.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.UUID;
+import org.folio.dcb.client.feign.CirculationItemClient;
+import org.folio.dcb.client.feign.HoldingsStorageClient;
+import org.folio.dcb.domain.dto.CirculationItem;
+import org.folio.dcb.domain.dto.CirculationItemCollection;
+import org.folio.dcb.domain.dto.DcbItem;
+import org.folio.dcb.service.impl.CirculationItemServiceImpl;
+import org.folio.dcb.service.impl.HoldingsServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+public class CirculationItemServiceImplTest {
+
+  @Mock
+  private CirculationItemClient circulationItemClient;
+  @Mock
+  private HoldingsServiceImpl holdingsService;
+  @Mock
+  private ItemService itemService;
+
+  @InjectMocks
+  private CirculationItemServiceImpl circulationItemService;
+
+  @Test
+  void checkIfItemExistsAndCreate_ShouldReturnExistingItem_WhenItemExists() {
+    // Mock
+    var randomUuid = UUID.randomUUID().toString();
+    var dcbItem = DcbItem.builder().barcode("barcode123").title("title").id(randomUuid).build();
+    var pickupServicePointId = "pickupPointId";
+
+    var existingItem = CirculationItem.builder().id(randomUuid).barcode("barcode123").build();
+    when(circulationItemClient.fetchItemByCqlQuery(any()))
+      .thenReturn(CirculationItemCollection.builder()
+        .items(Collections.singletonList(existingItem))
+        .build());
+
+    // Act
+    var result = circulationItemService.checkIfItemExistsAndCreate(dcbItem, pickupServicePointId);
+
+    // Assert
+    verify(circulationItemClient).fetchItemByCqlQuery(any());
+    assertEquals(existingItem, result);
+  }
+
+  @Test
+  void checkIfItemExistsAndCreate_ShouldCreateNewItem_WhenItemDoesNotExist() {
+    // Mock
+    var randomUuid = UUID.randomUUID().toString();
+    var dcbItem = DcbItem.builder().barcode("barcode123").title("title").id(randomUuid).build();
+    var pickupServicePointId = "pickupPointId";
+
+    when(circulationItemClient.fetchItemByCqlQuery(any()))
+      .thenReturn(CirculationItemCollection.builder().items(Collections.emptyList()).build());
+
+    var dcbHolding = HoldingsStorageClient.Holding.builder().id(randomUuid).build();
+    when(holdingsService.fetchDcbHoldingOrCreateIfMissing()).thenReturn(dcbHolding);
+
+    when(itemService.fetchItemMaterialTypeIdByMaterialTypeName(any())).thenReturn(randomUuid);
+
+    var createdItem = CirculationItem.builder().id(randomUuid).barcode("barcode123").build();
+    when(circulationItemClient.createCirculationItem(any(), any())).thenReturn(createdItem);
+
+    // Act
+    var result = circulationItemService.checkIfItemExistsAndCreate(dcbItem, pickupServicePointId);
+
+    // Assert
+    verify(circulationItemClient).fetchItemByCqlQuery(any());
+    verify(holdingsService).fetchDcbHoldingOrCreateIfMissing();
+    verify(circulationItemClient).createCirculationItem(any(), any());
+    assertEquals(createdItem, result);
+  }
+}

--- a/src/test/java/org/folio/dcb/service/HoldingsServiceImplTest.java
+++ b/src/test/java/org/folio/dcb/service/HoldingsServiceImplTest.java
@@ -1,0 +1,82 @@
+package org.folio.dcb.service;
+
+import static org.folio.dcb.utils.DCBConstants.HOLDING_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import feign.FeignException;
+import org.folio.dcb.client.feign.HoldingSourcesClient;
+import org.folio.dcb.client.feign.HoldingsStorageClient;
+import org.folio.dcb.exception.InventoryResourceOperationException;
+import org.folio.dcb.service.impl.HoldingsServiceImpl;
+import org.folio.spring.model.ResultList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HoldingsServiceImplTest {
+
+  @Mock
+  private HoldingsStorageClient holdingsStorageClient;
+  @Mock
+  private HoldingSourcesClient holdingSourcesClient;
+
+  @InjectMocks
+  private HoldingsServiceImpl holdingsService;
+
+  @Test
+  void fetchDcbHoldingOrCreateIfMissing_ShouldFetchHolding_WhenFound() {
+    // Mock
+    var expected = HoldingsStorageClient.Holding.builder().build();
+    when(holdingsStorageClient.findHolding(HOLDING_ID)).thenReturn(expected);
+
+    // Act
+    var holding = holdingsService.fetchDcbHoldingOrCreateIfMissing();
+
+    // Assert
+    verify(holdingsStorageClient).findHolding(HOLDING_ID);
+    assertEquals(expected, holding);
+  }
+
+  @Test
+  void fetchDcbHoldingOrCreateIfMissing_ShouldCreateHolding_WhenNotFound() {
+    // Mock
+    when(holdingsStorageClient.findHolding(HOLDING_ID))
+      .thenThrow(FeignException.NotFound.class);
+    var created = HoldingsStorageClient.Holding.builder().id(HOLDING_ID).build();
+    when(holdingsStorageClient.createHolding(any())).thenReturn(created);
+
+    // Also mock holdingSourcesClient for createHolding() path
+    var holdingSource = HoldingSourcesClient.HoldingSource.builder().id("sourceId").build();
+    when(holdingSourcesClient.querySourceByName(any())).thenReturn(ResultList.asSinglePage(holdingSource));
+
+    // Act
+    var holding = holdingsService.fetchDcbHoldingOrCreateIfMissing();
+
+    // Assert
+    assertEquals(created, holding);
+  }
+
+  @Test
+  void fetchDcbHoldingOrCreateIfMissing_ShouldThrowException_WhenCreateHoldingFails() {
+    // Mock
+    when(holdingsStorageClient.findHolding(HOLDING_ID))
+      .thenThrow(FeignException.NotFound.class);
+    doThrow(new RuntimeException("error")).when(holdingsStorageClient).createHolding(any());
+
+    // Also mock holdingSourcesClient for createHolding() path
+    var holdingSource = HoldingSourcesClient.HoldingSource.builder().id("sourceId").build();
+    when(holdingSourcesClient.querySourceByName(any())).thenReturn(ResultList.asSinglePage(holdingSource));
+
+    // Act & Assert
+    assertThrows(InventoryResourceOperationException.class,
+      () -> holdingsService.fetchDcbHoldingOrCreateIfMissing());
+  }
+}

--- a/src/test/java/org/folio/dcb/service/RequestServiceImplTest.java
+++ b/src/test/java/org/folio/dcb/service/RequestServiceImplTest.java
@@ -1,0 +1,55 @@
+package org.folio.dcb.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.folio.dcb.client.feign.CirculationClient;
+import org.folio.dcb.client.feign.HoldingsStorageClient;
+import org.folio.dcb.domain.dto.CirculationRequest;
+import org.folio.dcb.domain.dto.DcbItem;
+import org.folio.dcb.domain.dto.User;
+import org.folio.dcb.service.impl.HoldingsServiceImpl;
+import org.folio.dcb.service.impl.RequestServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestServiceImplTest {
+
+  @Mock
+  private CirculationClient circulationClient;
+  @Mock
+  private HoldingsServiceImpl holdingsService;
+
+  @InjectMocks
+  private RequestServiceImpl requestService;
+
+  @Test
+  void createHoldItemRequest_ShouldCreateRequest_WhenValidInput() {
+    // Mock
+    var randomUuid = UUID.randomUUID().toString();
+    var user = User.builder().username("username").id(randomUuid).barcode("barcode").build();
+    var item = DcbItem.builder().title ("title").id(randomUuid).build();
+    var pickupServicePointId = "pickupPointId";
+
+    var dcbHolding = HoldingsStorageClient.Holding.builder().id(randomUuid).build();
+    when(holdingsService.fetchDcbHoldingOrCreateIfMissing()).thenReturn(dcbHolding);
+
+    var expectedRequest = CirculationRequest.builder().id("requestId").build();
+    when(circulationClient.createRequest(any())).thenReturn(expectedRequest);
+
+    // Act
+    var request = requestService.createHoldItemRequest(user, item, pickupServicePointId);
+
+    // Assert
+    verify(holdingsService).fetchDcbHoldingOrCreateIfMissing();
+    verify(circulationClient).createRequest(any());
+    assertEquals(expectedRequest, request);
+  }
+}


### PR DESCRIPTION
### Purpose
Creation of Umbrella DCB Holding during tenant initialization at startup of `mod-dcb` may fail for any unpredictable reason. That's why, to make sure it exists, create this holding when referring to it if it is missing in inventory.

### Approach
- locate the all places where DCB holding is being referred/utilized
- create DCB inventory holding at those places if it is missing

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODDCB-187](https://folio-org.atlassian.net/browse/MODDCB-187)
