### PR TITLE
MODDCB-219: Added missing required permission for get transaction status api to fetch circ loan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * MODDCB-206: Populate locationCode for DCB Transaction API
 * MODDCB-216: Item Storage API version update from 10.1 to 11.0 [MODDCB-216](https://folio-org.atlassian.net/browse/MODDCB-216)
 * MODDCB-187: Create Umbrella DCB Inventory Holding if missing before using it [MODDCB-187](https://folio-org.atlassian.net/browse/MODDCB-187)
+* MODDCB-219: 403 from /circulation/loans during transaction status check [MODDCB-219](https://folio-org.atlassian.net/browse/MODDCB-219)
 
 ## v1.3.0 2025-03-13
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -135,7 +135,8 @@
           ],
           "pathPattern": "/transactions/{dcbTransactionId}/status",
           "permissionsRequired": [
-            "dcb.transactions.status.get"
+            "dcb.transactions.status.get",
+            "circulation.loans.collection.get"
           ],
           "modulePermissions": []
         },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -135,10 +135,11 @@
           ],
           "pathPattern": "/transactions/{dcbTransactionId}/status",
           "permissionsRequired": [
-            "dcb.transactions.status.get",
-            "circulation.loans.collection.get"
+            "dcb.transactions.status.get"
           ],
-          "modulePermissions": []
+          "modulePermissions": [
+            "circulation.loans.collection.get"
+          ]
         },
         {
           "methods": [


### PR DESCRIPTION
### Purpose
 Fixed permission issue in txn status API for fetching the circ loan

### Approach
Added missing required permission `circulation.loans.collection.get` to fetch the circ loan in module descriptor json file.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [x] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
_List any Jira issues related to this pull request._
[MODDCB-219](https://folio-org.atlassian.net/browse/MODDCB-219)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
