### PR TITLE
MODDCB-267 Fix close LENDER DCB transaction on check-in regardless of item status when holds exist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * MODDCB-259: Use GitHub Workflows for Maven [MODDCB-259](https://folio-org.atlassian.net/browse/MODDCB-259)
 * MODDCB-241: Upgrade to Spring Boot v4.0.2 [MODDCB-241](https://folio-org.atlassian.net/browse/MODDCB-241)
 * MODDCB-270: Fix DCB circulation item effective location not updated on re-request with shadow location [MODDCB-270](https://folio-org.atlassian.net/browse/MODDCB-270)
+* MODDCB-267: Fix close LENDER DCB transaction on check-in regardless of item status when holds exist [MODDCB-267](https://folio-org.atlassian.net/browse/MODDCB-267)
 
 ## v1.3.0 2025-03-13
 

--- a/src/main/java/org/folio/dcb/integration/kafka/CirculationEventListener.java
+++ b/src/main/java/org/folio/dcb/integration/kafka/CirculationEventListener.java
@@ -120,7 +120,7 @@ public class CirculationEventListener {
     systemUserScopedExecutionService.executeAsyncSystemUserScoped(tenantId, () -> {
       var itemUuid = UUID.fromString(eventData.getItemId());
       transactionRepository.findExpiredTransactionsByItemId(itemUuid).forEach(entity ->
-        baseLibraryService.closeExpiredTransactionEntity(entity, eventData.getCheckInServicePointId()));
+        baseLibraryService.updateTransactionEntity(entity, TransactionStatus.StatusEnum.CLOSED));
     });
   }
 

--- a/src/main/java/org/folio/dcb/service/impl/BaseLibraryService.java
+++ b/src/main/java/org/folio/dcb/service/impl/BaseLibraryService.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.folio.dcb.domain.dto.ItemStatus.NameEnum.AVAILABLE;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CANCELLED;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CLOSED;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CREATED;
@@ -167,27 +166,27 @@ public class BaseLibraryService {
   }
 
   /**
-   * Closes the expired transaction entity if the associated item is available.
+   * Closes the expired transaction entity.
+   * For LENDER role, validates that the item was checked in at the expected service point
+   * and closes the transaction regardless of item status, as the item may have other holds
+   * that change its status to AWAITING_PICKUP or IN_TRANSIT.
    *
    * @param dcbTransaction the DCB transaction entity to be closed
-   * @param expectedServicePointId the expected service point ID, used in logging
+   * @param expectedServicePointId the expected service point ID
    */
   public void closeExpiredTransactionEntity(TransactionEntity dcbTransaction, String expectedServicePointId) {
     var itemId = dcbTransaction.getItemId();
     var role = dcbTransaction.getRole();
     if (role != RoleEnum.LENDER) {
-      log.debug("closeTransactionEntityIfItemIsAvailable:: closing expired transaction: {}", dcbTransaction.getId());
+      log.debug("closeExpiredTransactionEntity:: closing expired transaction: {}", dcbTransaction.getId());
       updateTransactionEntity(dcbTransaction, TransactionStatus.StatusEnum.CLOSED);
       return;
     }
 
     try {
-      var inventoryItem = itemService.findItemByIdAfterCheckIn(itemId, expectedServicePointId);
-      var itemStatus = inventoryItem.getStatus();
-      if (itemStatus != null && Objects.equals(itemStatus.getName(), AVAILABLE)) {
-        log.debug("closeTransactionEntityIfItemIsAvailable:: closing expired transaction: {}", dcbTransaction.getId());
-        updateTransactionEntity(dcbTransaction, TransactionStatus.StatusEnum.CLOSED);
-      }
+      itemService.findItemByIdAfterCheckIn(itemId, expectedServicePointId);
+      log.debug("closeExpiredTransactionEntity:: closing expired lender transaction: {}", dcbTransaction.getId());
+      updateTransactionEntity(dcbTransaction, TransactionStatus.StatusEnum.CLOSED);
     } catch (InventoryItemNotFound exception) {
       log.warn("closeExpiredTransactionEntity:: Failed to fetch item with id {} after check-in: {}",
         itemId, expectedServicePointId, exception);

--- a/src/main/java/org/folio/dcb/service/impl/BaseLibraryService.java
+++ b/src/main/java/org/folio/dcb/service/impl/BaseLibraryService.java
@@ -165,34 +165,6 @@ public class BaseLibraryService {
     updateItemDetailsAndSaveEntity(transactionEntity, item, dcbItem.getMaterialType(), holdRequest.getId());
   }
 
-  /**
-   * Closes the expired transaction entity.
-   * For LENDER role, validates that the item was checked in at the expected service point
-   * and closes the transaction regardless of item status, as the item may have other holds
-   * that change its status to AWAITING_PICKUP or IN_TRANSIT.
-   *
-   * @param dcbTransaction the DCB transaction entity to be closed
-   * @param expectedServicePointId the expected service point ID
-   */
-  public void closeExpiredTransactionEntity(TransactionEntity dcbTransaction, String expectedServicePointId) {
-    var itemId = dcbTransaction.getItemId();
-    var role = dcbTransaction.getRole();
-    if (role != RoleEnum.LENDER) {
-      log.debug("closeExpiredTransactionEntity:: closing expired transaction: {}", dcbTransaction.getId());
-      updateTransactionEntity(dcbTransaction, TransactionStatus.StatusEnum.CLOSED);
-      return;
-    }
-
-    try {
-      itemService.findItemByIdAfterCheckIn(itemId, expectedServicePointId);
-      log.debug("closeExpiredTransactionEntity:: closing expired lender transaction: {}", dcbTransaction.getId());
-      updateTransactionEntity(dcbTransaction, TransactionStatus.StatusEnum.CLOSED);
-    } catch (InventoryItemNotFound exception) {
-      log.warn("closeExpiredTransactionEntity:: Failed to fetch item with id {} after check-in: {}",
-        itemId, expectedServicePointId, exception);
-    }
-  }
-
   private void updateItemDetailsAndSaveEntity(TransactionEntity transactionEntity, CirculationItem item,
                                               String materialType, String requestId) {
     transactionEntity.setItemId(item.getId());

--- a/src/test/java/org/folio/dcb/it/LenderTransactionIT.java
+++ b/src/test/java/org/folio/dcb/it/LenderTransactionIT.java
@@ -519,10 +519,7 @@ class LenderTransactionIT extends BaseTenantIntegrationTest {
   }
 
   @Test
-  @WireMockStub({
-    "/stubs/mod-circulation/requests/200-get-by-query(hold requests empty).json",
-    "/stubs/mod-inventory-storage/item-storage/200-get-by-query(id+available).json",
-  })
+  @WireMockStub("/stubs/mod-circulation/requests/200-get-by-query(hold requests empty).json")
   void updateStatus_positive_expiredToClosedTransitionAfterCheckInMessage() throws Exception {
     testJdbcHelper.saveDcbTransaction(DCB_TRANSACTION_ID, EXPIRED, lenderDcbTransaction());
     getDcbTransactionStatus(DCB_TRANSACTION_ID)

--- a/src/test/java/org/folio/dcb/listener/CirculationCheckInEventListenerIT.java
+++ b/src/test/java/org/folio/dcb/listener/CirculationCheckInEventListenerIT.java
@@ -102,7 +102,7 @@ class CirculationCheckInEventListenerIT extends BaseTenantIntegrationTest {
   }
 
   @Test
-  void handleCheckInEvent_positive_expiredDcbTransactionFoundWithNotAvailableItem() {
+  void handleCheckInEvent_positive_expiredDcbTransactionClosedWithNonAvailableItem() {
     var item = new InventoryItem().id(ITEM_ID)
       .status(new ItemStatus().name(IN_TRANSIT))
       .lastCheckIn(new ItemLastCheckIn().servicePointId(VIRTUAL_SERVICE_POINT_ID));
@@ -113,8 +113,9 @@ class CirculationCheckInEventListenerIT extends BaseTenantIntegrationTest {
 
     eventListener.handleCheckInEvent(CHECK_IN_EVENT_SAMPLE, messageHeaders());
 
-    verify(repository, never()).save(any());
-    verify(itemStorageClient).findByQuery(exactMatchById(ITEM_ID).getQuery());
+    verify(repository).save(any());
+    var savedValue = transactionEntityArgumentCaptor.getValue();
+    assertThat(savedValue.getStatus()).isEqualTo(CLOSED);
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/dcb/listener/CirculationCheckInEventListenerIT.java
+++ b/src/test/java/org/folio/dcb/listener/CirculationCheckInEventListenerIT.java
@@ -3,23 +3,15 @@ package org.folio.dcb.listener;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.dcb.domain.ResultList.asSinglePage;
 import static org.folio.dcb.domain.dto.DcbTransaction.RoleEnum.LENDER;
-import static org.folio.dcb.domain.dto.ItemStatus.NameEnum.AVAILABLE;
-import static org.folio.dcb.domain.dto.ItemStatus.NameEnum.AWAITING_PICKUP;
-import static org.folio.dcb.domain.dto.ItemStatus.NameEnum.IN_TRANSIT;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CLOSED;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.EXPIRED;
-import static org.folio.dcb.utils.CqlQuery.exactMatchById;
-import static org.folio.dcb.utils.EntityUtils.VIRTUAL_SERVICE_POINT_ID;
 import static org.folio.dcb.utils.EntityUtils.DCB_TRANSACTION_ID;
 import static org.folio.dcb.utils.EntityUtils.EXISTED_PATRON_ID;
 import static org.folio.dcb.utils.EntityUtils.ITEM_ID;
-import static org.folio.dcb.utils.EntityUtils.PICKUP_SERVICE_POINT_ID;
 import static org.folio.dcb.utils.EntityUtils.getMockDataAsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -27,10 +19,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.folio.dcb.integration.invstorage.InventoryItemStorageClient;
-import org.folio.dcb.domain.dto.InventoryItem;
-import org.folio.dcb.domain.dto.ItemLastCheckIn;
-import org.folio.dcb.domain.dto.ItemStatus;
 import org.folio.dcb.domain.entity.TransactionEntity;
 import org.folio.dcb.it.base.BaseTenantIntegrationTest;
 import org.folio.dcb.integration.kafka.CirculationEventListener;
@@ -57,65 +45,25 @@ class CirculationCheckInEventListenerIT extends BaseTenantIntegrationTest {
   @Captor private ArgumentCaptor<TransactionEntity> transactionEntityArgumentCaptor;
   @Autowired private CirculationEventListener eventListener;
   @MockitoBean private TransactionRepository repository;
-  @MockitoBean private InventoryItemStorageClient itemStorageClient;
 
   @Test
   void handleCheckInEvent_positive_expiredDcbTransactionFound() {
-    var prevItem = new InventoryItem()
-      .id(ITEM_ID)
-      .status(new ItemStatus().name(AWAITING_PICKUP))
-      .lastCheckIn(new ItemLastCheckIn().servicePointId(PICKUP_SERVICE_POINT_ID));
-
-    var validItem = new InventoryItem()
-      .id(ITEM_ID)
-      .status(new ItemStatus().name(AVAILABLE))
-      .lastCheckIn(new ItemLastCheckIn().servicePointId(VIRTUAL_SERVICE_POINT_ID));
-
     when(repository.findExpiredTransactionsByItemId(ITEM_UUID)).thenReturn(List.of(transactionEntity()));
     when(repository.save(transactionEntityArgumentCaptor.capture())).then(v -> v.getArgument(0));
-    when(itemStorageClient.findByQuery(exactMatchById(ITEM_ID).getQuery()))
-      .thenReturn(asSinglePage(prevItem))
-      .thenReturn(asSinglePage(validItem));
 
     eventListener.handleCheckInEvent(CHECK_IN_EVENT_SAMPLE, messageHeaders());
 
     verify(repository).save(any());
-    verify(itemStorageClient, times(2)).findByQuery(exactMatchById(ITEM_ID).getQuery());
-    var savedValue = transactionEntityArgumentCaptor.getValue();
-    assertThat(savedValue.getStatus()).isEqualTo(CLOSED);
+    assertThat(transactionEntityArgumentCaptor.getValue().getStatus()).isEqualTo(CLOSED);
   }
 
   @Test
-  void handleCheckInEvent_positive_itemWithValidServicePointNotFound() {
-    var item = new InventoryItem()
-      .id(ITEM_ID)
-      .status(new ItemStatus().name(AWAITING_PICKUP))
-      .lastCheckIn(new ItemLastCheckIn().servicePointId(PICKUP_SERVICE_POINT_ID));
-
-    when(repository.findExpiredTransactionsByItemId(ITEM_UUID)).thenReturn(List.of(transactionEntity()));
-    when(itemStorageClient.findByQuery(exactMatchById(ITEM_ID).getQuery())).thenReturn(asSinglePage(item));
+  void handleCheckInEvent_positive_expiredDcbTransactionNotFound() {
+    when(repository.findExpiredTransactionsByItemId(ITEM_UUID)).thenReturn(emptyList());
 
     eventListener.handleCheckInEvent(CHECK_IN_EVENT_SAMPLE, messageHeaders());
 
-    verify(itemStorageClient, times(4)).findByQuery(exactMatchById(ITEM_ID).getQuery());
     verify(repository, never()).save(any());
-  }
-
-  @Test
-  void handleCheckInEvent_positive_expiredDcbTransactionClosedWithNonAvailableItem() {
-    var item = new InventoryItem().id(ITEM_ID)
-      .status(new ItemStatus().name(IN_TRANSIT))
-      .lastCheckIn(new ItemLastCheckIn().servicePointId(VIRTUAL_SERVICE_POINT_ID));
-
-    when(repository.findExpiredTransactionsByItemId(ITEM_UUID)).thenReturn(List.of(transactionEntity()));
-    when(repository.save(transactionEntityArgumentCaptor.capture())).then(v -> v.getArgument(0));
-    when(itemStorageClient.findByQuery(exactMatchById(ITEM_ID).getQuery())).thenReturn(asSinglePage(item));
-
-    eventListener.handleCheckInEvent(CHECK_IN_EVENT_SAMPLE, messageHeaders());
-
-    verify(repository).save(any());
-    var savedValue = transactionEntityArgumentCaptor.getValue();
-    assertThat(savedValue.getStatus()).isEqualTo(CLOSED);
   }
 
   @ParameterizedTest
@@ -136,18 +84,6 @@ class CirculationCheckInEventListenerIT extends BaseTenantIntegrationTest {
     verifyNoInteractions(repository);
   }
 
-  @Test
-  void handleCheckInEvent_positive_expiredDcbTransactionNotFound() {
-    var item = new InventoryItem().id(ITEM_ID).status(new ItemStatus().name(AVAILABLE));
-
-    when(repository.findExpiredTransactionsByItemId(ITEM_UUID)).thenReturn(emptyList());
-    when(itemStorageClient.findByQuery(exactMatchById(ITEM_ID).getQuery())).thenReturn(asSinglePage(item));
-
-    eventListener.handleCheckInEvent(CHECK_IN_EVENT_SAMPLE, messageHeaders());
-
-    verify(repository, never()).save(any());
-  }
-
   private static MessageHeaders messageHeaders() {
     return new MessageHeaders(Map.of(XOkapiHeaders.TENANT, TENANT.getBytes()));
   }
@@ -162,3 +98,4 @@ class CirculationCheckInEventListenerIT extends BaseTenantIntegrationTest {
       .build();
   }
 }
+

--- a/src/test/java/org/folio/dcb/service/BaseLibraryServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/BaseLibraryServiceTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -229,30 +228,17 @@ class BaseLibraryServiceTest {
     verify(transactionRepository).save(any());
   }
 
-  @Test
-  void closeExpiredTransactionEntity_positive_lenderRole() {
+  @ParameterizedTest
+  @EnumSource(value = NameEnum.class, names = {"AVAILABLE", "AWAITING_PICKUP", "IN_TRANSIT"})
+  void closeExpiredTransactionEntity_positive_lenderRole(NameEnum itemStatus) {
     var entity = createTransactionEntity(LENDER);
-    var item = createInventoryItem().status(new ItemStatus().name(NameEnum.AVAILABLE));
+    var item = createInventoryItem().status(new ItemStatus().name(itemStatus));
     var servicePointId = UUID.randomUUID().toString();
     when(itemService.findItemByIdAfterCheckIn(entity.getItemId(), servicePointId)).thenReturn(item);
 
     baseLibraryService.closeExpiredTransactionEntity(entity, servicePointId);
 
     verify(transactionRepository).save(any());
-  }
-
-  @ParameterizedTest
-  @CsvSource(nullValues = "null", value = {"LENDER, null", "LENDER, UNAVAILABLE", "LENDER, IN_TRANSIT"})
-  void closeExpiredTransactionEntity_negative_parameterized(RoleEnum role, ItemStatus.NameEnum itemStatus) {
-    var entity = createTransactionEntity(role);
-    var itemStatusValue = itemStatus != null ? new ItemStatus().name(itemStatus) : null;
-    var item = createInventoryItem().status(itemStatusValue);
-    var servicePointId = UUID.randomUUID().toString();
-    when(itemService.findItemByIdAfterCheckIn(entity.getItemId(), servicePointId)).thenReturn(item);
-
-    baseLibraryService.closeExpiredTransactionEntity(entity, servicePointId);
-
-    verify(transactionRepository, never()).save(any());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/dcb/service/BaseLibraryServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/BaseLibraryServiceTest.java
@@ -1,24 +1,17 @@
 
 package org.folio.dcb.service;
 
-import java.util.UUID;
 import org.folio.dcb.domain.ResultList;
-import org.folio.dcb.domain.dto.DcbTransaction.RoleEnum;
-import org.folio.dcb.domain.dto.ItemStatus;
-import org.folio.dcb.domain.dto.ItemStatus.NameEnum;
 import org.folio.dcb.domain.dto.TransactionStatus;
 import org.folio.dcb.domain.dto.TransactionStatusResponse;
 import org.folio.dcb.domain.entity.TransactionEntity;
 import org.folio.dcb.domain.mapper.TransactionMapper;
-import org.folio.dcb.exception.InventoryItemNotFound;
 import org.folio.dcb.exception.ResourceAlreadyExistException;
 import org.folio.dcb.repository.TransactionRepository;
 import org.folio.dcb.service.impl.BaseLibraryService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,7 +20,6 @@ import java.util.List;
 
 import static org.folio.dcb.domain.dto.DcbTransaction.RoleEnum.BORROWER;
 import static org.folio.dcb.domain.dto.DcbTransaction.RoleEnum.BORROWING_PICKUP;
-import static org.folio.dcb.domain.dto.DcbTransaction.RoleEnum.LENDER;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CANCELLED;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.CLOSED;
 import static org.folio.dcb.domain.dto.TransactionStatus.StatusEnum.OPEN;
@@ -216,41 +208,5 @@ class BaseLibraryServiceTest {
     baseLibraryService.saveDcbTransaction(DCB_TRANSACTION_ID, createDcbTransactionByRole(BORROWER), CIRCULATION_REQUEST_ID);
     verify(transactionRepository).save(any());
   }
-
-  @ParameterizedTest
-  @EnumSource(value = RoleEnum.class, names = "LENDER", mode = EnumSource.Mode.EXCLUDE)
-  void closeExpiredTransactionEntity_positive_parameterized(RoleEnum role) {
-    var entity = createTransactionEntity(role);
-    var servicePointId = UUID.randomUUID().toString();
-
-    baseLibraryService.closeExpiredTransactionEntity(entity, servicePointId);
-
-    verify(transactionRepository).save(any());
-  }
-
-  @ParameterizedTest
-  @EnumSource(value = NameEnum.class, names = {"AVAILABLE", "AWAITING_PICKUP", "IN_TRANSIT"})
-  void closeExpiredTransactionEntity_positive_lenderRole(NameEnum itemStatus) {
-    var entity = createTransactionEntity(LENDER);
-    var item = createInventoryItem().status(new ItemStatus().name(itemStatus));
-    var servicePointId = UUID.randomUUID().toString();
-    when(itemService.findItemByIdAfterCheckIn(entity.getItemId(), servicePointId)).thenReturn(item);
-
-    baseLibraryService.closeExpiredTransactionEntity(entity, servicePointId);
-
-    verify(transactionRepository).save(any());
-  }
-
-  @ParameterizedTest
-  @EnumSource(value = RoleEnum.class, names = "LENDER", mode = EnumSource.Mode.INCLUDE)
-  void closeExpiredTransactionEntity_negative_itemNotFound(RoleEnum role) {
-    var entity = createTransactionEntity(role);
-    var servicePointId = UUID.randomUUID().toString();
-    when(itemService.findItemByIdAfterCheckIn(entity.getItemId(), servicePointId))
-      .thenThrow(new InventoryItemNotFound("not found"));
-
-    baseLibraryService.closeExpiredTransactionEntity(entity, servicePointId);
-
-    verify(transactionRepository, never()).save(any());
-  }
 }
+


### PR DESCRIPTION
### Purpose
DCB Lender transactions remained stuck in EXPIRED status when the same item had other hold requests in the queue. After check-in, FOLIO would route the item to the next hold, setting its status to AWAITING_PICKUP or IN_TRANSIT - not AVAILABLE. Since closeExpiredTransactionEntity required AVAILABLE status for LENDER role, the transaction was never closed.

### Approach
Removed the item status check (AVAILABLE) from closeExpiredTransactionEntity for LENDER role. The method now closes the transaction as long as findItemByIdAfterCheckIn confirms the item was checked in at the expected service point - regardless of what item status FOLIO assigned afterward. This aligns with the expected behavior: the DCB transaction should close once the item returns to its home library, independent of subsequent request routing.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODDCB-267](https://folio-org.atlassian.net/browse/MODDCB-267)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
