### PR TITLE
MODDCB-271 Allow new transaction creation when EXPIRED transaction exists for same item

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * MODDCB-259: Use GitHub Workflows for Maven [MODDCB-259](https://folio-org.atlassian.net/browse/MODDCB-259)
 * MODDCB-241: Upgrade to Spring Boot v4.0.2 [MODDCB-241](https://folio-org.atlassian.net/browse/MODDCB-241)
 * MODDCB-270: Fix DCB circulation item effective location not updated on re-request with shadow location [MODDCB-270](https://folio-org.atlassian.net/browse/MODDCB-270)
+* MODDCB-271: Allow new transaction creation when EXPIRED transaction exists for same item [MODDCB-271](https://folio-org.atlassian.net/browse/MODDCB-271)
 
 ## v1.3.0 2025-03-13
 

--- a/src/main/java/org/folio/dcb/repository/TransactionRepository.java
+++ b/src/main/java/org/folio/dcb/repository/TransactionRepository.java
@@ -15,7 +15,7 @@ public interface TransactionRepository extends JpaRepository<TransactionEntity, 
   @Query(value = "SELECT * FROM transactions where item_id = :itemId AND status not in ('CLOSED', 'CANCELLED', 'ERROR', 'CREATED', 'OPEN')", nativeQuery = true)
   Optional<TransactionEntity> findTransactionByItemIdAndStatusNotInClosed(@Param("itemId") UUID itemId);
 
-  @Query(value = "SELECT * FROM transactions where item_id = :itemId AND status not in ('CLOSED', 'CANCELLED', 'ERROR')", nativeQuery = true)
+  @Query(value = "SELECT * FROM transactions where item_id = :itemId AND status not in ('CLOSED', 'CANCELLED', 'ERROR', 'EXPIRED')", nativeQuery = true)
   List<TransactionEntity> findTransactionsByItemIdAndStatusNotInClosed(@Param("itemId") UUID itemId);
 
   @Query(value = "SELECT * FROM transactions where item_id = :itemId AND status = 'EXPIRED'", nativeQuery = true)

--- a/src/test/java/org/folio/dcb/it/BorrowerTransactionIT.java
+++ b/src/test/java/org/folio/dcb/it/BorrowerTransactionIT.java
@@ -177,6 +177,26 @@ class BorrowerTransactionIT extends BaseTenantIntegrationTest {
     "/stubs/mod-circulation-item/200-get-by-query(barcode).json",
     "/stubs/mod-circulation/requests/201-post(any).json",
   })
+  void createTransaction_positive_expiredTransactionExistsForSameItem() throws Exception {
+    testJdbcHelper.saveDcbTransaction("571b0a2c-8883-40b5-a449-d41fe6000001", EXPIRED, borrowerDcbTransaction());
+
+    postDcbTransaction(DCB_TRANSACTION_ID, borrowerDcbTransaction())
+      .andExpect(jsonPath("$.status").value("CREATED"));
+
+    auditEntityVerifier.assertThatLatestEntityIsNotDuplicate(DCB_TRANSACTION_ID);
+    verifyPostCirculationRequestCalledOnce(PATRON_TYPE_USER_ID);
+  }
+
+  @Test
+  @WireMockStub({
+    "/stubs/mod-inventory-storage/service-points/200-get-by-name(Virtual).json",
+    "/stubs/mod-inventory-storage/service-points/204-put(Virtual).json",
+    "/stubs/mod-calendar/calendars/200-get-all.json",
+    "/stubs/mod-users/users/200-get-by-query(patron).json",
+    "/stubs/mod-inventory-storage/item-storage/200-get-by-query(barcode empty).json",
+    "/stubs/mod-circulation-item/200-get-by-query(barcode).json",
+    "/stubs/mod-circulation/requests/201-post(any).json",
+  })
   void createTransaction_positive_withPatronTypeUser() throws Exception {
     var transaction = borrowerDcbTransaction();
     postDcbTransaction(DCB_TRANSACTION_ID, transaction)

--- a/src/test/java/org/folio/dcb/it/PickupTransactionIT.java
+++ b/src/test/java/org/folio/dcb/it/PickupTransactionIT.java
@@ -213,6 +213,25 @@ class PickupTransactionIT extends BaseTenantIntegrationTest {
   }
 
   @Test
+  @WireMockStub({
+    "/stubs/mod-users/users/200-get-by-query(dcb user).json",
+    "/stubs/mod-inventory-storage/item-storage/200-get-by-query(barcode empty).json",
+    "/stubs/mod-circulation-item/200-get-by-query(barcode).json",
+    "/stubs/mod-users/groups/200-get-by-query(staff).json",
+    "/stubs/mod-circulation/requests/201-post(any).json",
+  })
+  void createTransaction_positive_expiredTransactionExistsForSameItem() throws Exception {
+    testJdbcHelper.saveDcbTransaction("571b0a2c-8883-40b5-a449-d41fe6000002", EXPIRED, pickupDcbTransaction());
+
+    var dcbPatron = dcbPatron(EXISTED_PATRON_ID);
+    postDcbTransaction(DCB_TRANSACTION_ID, pickupDcbTransaction(dcbPatron))
+      .andExpect(jsonPath("$.status").value("CREATED"));
+
+    auditEntityVerifier.assertThatLatestEntityIsNotDuplicate(DCB_TRANSACTION_ID);
+    verifyPostCirculationRequestCalledOnce(EXISTED_PATRON_ID);
+  }
+
+  @Test
   @WireMockStub("/stubs/mod-circulation/check-in-by-barcode/201-post(random SP).json")
   void updateTransactionStatus_positive_fromCreatedToOpen() throws Exception {
     testJdbcHelper.saveDcbTransaction(DCB_TRANSACTION_ID, CREATED, pickupDcbTransaction());

--- a/src/test/java/org/folio/dcb/service/BaseLibraryServiceTest.java
+++ b/src/test/java/org/folio/dcb/service/BaseLibraryServiceTest.java
@@ -172,6 +172,25 @@ class BaseLibraryServiceTest {
   }
 
   @Test
+  void createBorrowingTransaction_positive_expiredTransactionExistsForSameItem() {
+    var item = createDcbItem();
+    var user = createUser();
+    user.setType("shadow");
+
+    when(userService.fetchUser(any())).thenReturn(user);
+    when(requestService.createHoldItemRequest(any(), any(), anyString())).thenReturn(createCirculationRequest());
+    when(transactionMapper.mapToEntity(any(), any())).thenReturn(createTransactionEntity());
+    when(itemService.fetchItemByBarcode(item.getBarcode())).thenReturn(new ResultList<>());
+    when(circulationItemService.checkIfItemExistsAndCreate(any(), any())).thenReturn(createCirculationItem());
+    when(transactionRepository.findTransactionsByItemIdAndStatusNotInClosed(any())).thenReturn(List.of());
+
+    var response = baseLibraryService.createBorrowingLibraryTransaction(DCB_TRANSACTION_ID, createDcbTransactionByRole(BORROWER), PICKUP_SERVICE_POINT_ID);
+
+    verify(transactionRepository).save(any());
+    Assertions.assertEquals(TransactionStatusResponse.StatusEnum.CREATED, response.getStatus());
+  }
+
+  @Test
   void checkItemIfExistsInInventory() {
     var item = createDcbItem();
     var inventoryItem = createInventoryItem();


### PR DESCRIPTION
### Purpose
EXPIRED transactions are terminal/stale — they should not block new transactions for the same item, just like CLOSED/CANCELLED/ERROR ones.

### Approach
Exclude EXPIRED status from the "active transaction exists" check query in TransactionRepository.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODDCB-271](https://folio-org.atlassian.net/browse/MODDCB-271)

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
