### PR TITLE
MODDCB-270 Fix shadow location not updated on re-request when transaction entity has existing locationCode

### DIFF
--- a/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
+++ b/src/main/java/org/folio/dcb/domain/mapper/TransactionMapper.java
@@ -102,7 +102,6 @@ public class TransactionMapper {
       .barcode(dcbUpdateItem.getBarcode())
       .materialType(dcbUpdateItem.getMaterialType())
       .title(entity.getItemTitle())
-      .locationCode(entity.getItemLocationCode())
       .build();
   }
 

--- a/src/test/java/org/folio/dcb/it/FlexibleEffectiveLocationIT.java
+++ b/src/test/java/org/folio/dcb/it/FlexibleEffectiveLocationIT.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.folio.dcb.domain.dto.DcbAgency;
 import org.folio.dcb.domain.dto.DcbLocation;
+import org.folio.dcb.domain.dto.DcbTransaction;
 import org.folio.dcb.domain.dto.DcbUpdateItem;
 import org.folio.dcb.domain.dto.DcbUpdateTransaction;
 import org.folio.dcb.domain.dto.ShadowLocationRefreshBody;
@@ -93,6 +94,11 @@ class FlexibleEffectiveLocationIT {
         .materialType("DVD")
         .build())
       .build();
+  }
+
+  private static DcbTransaction withShadowLocationCode(DcbTransaction tx) {
+    tx.getItem().locationCode("SHADOW_LOC_OLD");
+    return tx;
   }
 
   @Nested
@@ -252,7 +258,7 @@ class FlexibleEffectiveLocationIT {
     })
     void updateTransaction_positive_effectiveLocationUpdatedForExistingItem() throws Exception {
       testJdbcHelper.saveDcbTransaction(DCB_TRANSACTION_ID, CREATED,
-        borrowerDcbTransaction(dcbPatron(PATRON_TYPE_USER_ID)));
+        withShadowLocationCode(borrowerDcbTransaction(dcbPatron(PATRON_TYPE_USER_ID))));
 
       putDcbTransactionDetailsAttempt(DCB_TRANSACTION_ID, updateTransactionWithShadowLibrary())
         .andExpect(status().isNoContent());
@@ -408,7 +414,7 @@ class FlexibleEffectiveLocationIT {
     })
     void updateTransaction_positive_effectiveLocationUpdatedForExistingItem() throws Exception {
       testJdbcHelper.saveDcbTransaction(DCB_TRANSACTION_ID, CREATED,
-        borrowingPickupDcbTransaction(dcbPatron(PATRON_TYPE_USER_ID)));
+        withShadowLocationCode(borrowingPickupDcbTransaction(dcbPatron(PATRON_TYPE_USER_ID))));
 
       putDcbTransactionDetailsAttempt(DCB_TRANSACTION_ID, updateTransactionWithShadowLibrary())
         .andExpect(status().isNoContent());
@@ -562,7 +568,7 @@ class FlexibleEffectiveLocationIT {
     })
     void updateTransaction_positive_effectiveLocationUpdatedForExistingItem() throws Exception {
       testJdbcHelper.saveDcbTransaction(DCB_TRANSACTION_ID, CREATED,
-        pickupDcbTransaction(dcbPatron(PATRON_TYPE_USER_ID)));
+        withShadowLocationCode(pickupDcbTransaction(dcbPatron(PATRON_TYPE_USER_ID))));
 
       putDcbTransactionDetailsAttempt(DCB_TRANSACTION_ID, updateTransactionWithShadowLibrary())
         .andExpect(status().isNoContent());


### PR DESCRIPTION
### Purpose
A follow-up fix for a previously merged PR #255 . When a DCB transaction was originally created with a shadow locationCode stored in the entity, subsequent re-requests (PUT) would silently keep the old shadow location instead of resolving the new one. Affected all 3 roles: Borrower, BorrowingPickup, Pickup.

### Approach
   - Removed .locationCode(entity.getItemLocationCode()) from TransactionMapper.convertTransactionUpdateItemToDcbItem — the old locationCode from the entity was incorrectly carried over into the update flow, causing resolveEffectiveLocationId to short-circuit on the stale value instead of resolving via the new lendingLibraryCode
   - Tests now fail without the fix and pass with it

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODDCB-270](https://folio-org.atlassian.net/browse/MODDCB-270)
